### PR TITLE
feat(interpreter-parser): added basic parser and syntax error functionality

### DIFF
--- a/src/app/logic/error.spec.ts
+++ b/src/app/logic/error.spec.ts
@@ -1,19 +1,26 @@
+import { PositionTracker } from './position-tracker';
 import { Error } from './error';
 
 describe('Error tests', () => {
   describe('getErrorMessage tests', () => {
-    it(`should return 'Error' for type='Error' and no details passed`, () => {
+    it(`should return 'Error' with line and column numbers for type='Error' and no details passed`, () => {
 
-      const error: Error = new Error('Error');
-      const expected = 'Error';
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
+      const error: Error = new Error('Error', posStart, posEnd);
+      const expected = `Error\nAt line: ${posStart.getLine()} column: ${posStart.getColumn()}` +
+                       ` and ends at line: ${posEnd.getLine()} column: ${posEnd.getColumn()}`;
 
       expect(error.getErrorMessage()).toEqual(expected);
     });
 
-    it(`should return 'Error: details' for type='Error' and details='details'`, () => {
+    it(`should return 'Error: details' with line and column numbers for type='Error' and details='details'`, () => {
 
-      const error: Error = new Error('Error', 'details');
-      const expected = 'Error: details';
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
+      const error: Error = new Error('Error', posStart, posEnd, 'details');
+      const expected = `Error: details\nAt line: ${posStart.getLine()} column: ${posStart.getColumn()}` +
+                       ` and ends at line: ${posEnd.getLine()} column: ${posEnd.getColumn()}`;
 
       expect(error.getErrorMessage()).toEqual(expected);
     });

--- a/src/app/logic/error.ts
+++ b/src/app/logic/error.ts
@@ -1,14 +1,22 @@
+import { PositionTracker } from './position-tracker';
+
 export class Error {
 
-    constructor(private type: string, private details?: string) {}
+    constructor(private type: string, private posStart: PositionTracker,
+                private posEnd: PositionTracker, private details?: string) {}
 
     public getErrorMessage(): string {
 
+      const lineMessage = `At line: ${this.posStart.getLine()} column: ` +
+                          `${this.posStart.getColumn()} and ends at line: ` +
+                          `${this.posEnd.getLine()} column: ${this.posEnd.getColumn()}`;
+
       if (this.details === undefined) {
-        return this.type;
+        return `${this.type}\n${lineMessage}`;
       }
       else {
-        return `${this.type}: ${this.details}`;
+        let message = `${this.type}: ${this.details}\n${lineMessage}`;
+        return message;
       }
     }
 }

--- a/src/app/logic/invalid-character-error.spec.ts
+++ b/src/app/logic/invalid-character-error.spec.ts
@@ -1,12 +1,17 @@
 import { InvalidCharacterError } from './invalid-character-error';
+import { PositionTracker } from './position-tracker';
 
 describe('InvalidCharacterError tests', () => {
   describe('getErrorMessage tests', () => {
-    it(`should return error message with type as 'InvalidCharacterError' and details as passed`, () => {
+    it(`should return error message with type as 'InvalidCharacterError' and details as passed with correct line and column number`, () => {
 
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
       const details = `character '@' is invalid.`;
-      const error: InvalidCharacterError = new InvalidCharacterError(details);
-      const expected = `InvalidCharacterError: ${details}`;
+      const error: InvalidCharacterError = new InvalidCharacterError(details, posStart, posEnd);
+      const expected = `InvalidCharacterError: ${details}\nAt line: ${posStart.getLine()} column:` +
+                       ` ${posStart.getColumn()} and ends at line: ${posEnd.getLine()} column:` +
+                       ` ${posEnd.getColumn()}`;
 
       expect(error.getErrorMessage()).toEqual(expected);
     });

--- a/src/app/logic/invalid-character-error.ts
+++ b/src/app/logic/invalid-character-error.ts
@@ -1,8 +1,9 @@
+import { PositionTracker } from './position-tracker';
 import { Error } from './error';
 
 export class InvalidCharacterError extends Error {
 
-  constructor(details: string) {
-    super('InvalidCharacterError', details);
+  constructor(details: string, posStart: PositionTracker, posEnd: PositionTracker) {
+    super('InvalidCharacterError', posStart, posEnd, details);
   }
 }

--- a/src/app/logic/invalid-syntax-error.spec.ts
+++ b/src/app/logic/invalid-syntax-error.spec.ts
@@ -1,12 +1,17 @@
 import { InvalidSyntaxError } from './invalid-syntax-error';
+import { PositionTracker } from './position-tracker';
 
 describe('InvalidSyntaxError tests', () => {
   describe('getErrorMessage tests', () => {
-    it(`should return error message with type as 'InvalidSyntaxError' and details as passed`, () => {
+    it(`should return error message with type as 'InvalidSyntaxError' and details as passed with correct line and column number`, () => {
 
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
       const details = `missing ')'.`;
-      const error: InvalidSyntaxError = new InvalidSyntaxError(details);
-      const expected = `InvalidSyntaxError: ${details}`;
+      const error: InvalidSyntaxError = new InvalidSyntaxError(details, posStart, posEnd);
+      const expected = `InvalidSyntaxError: ${details}\nAt line: ${posStart.getLine()} column:` +
+                       ` ${posStart.getColumn()} and ends at line: ${posEnd.getLine()} column:` +
+                       ` ${posEnd.getColumn()}`;
 
       expect(error.getErrorMessage()).toEqual(expected);
     });

--- a/src/app/logic/invalid-syntax-error.spec.ts
+++ b/src/app/logic/invalid-syntax-error.spec.ts
@@ -1,0 +1,14 @@
+import { InvalidSyntaxError } from './invalid-syntax-error';
+
+describe('InvalidSyntaxError tests', () => {
+  describe('getErrorMessage tests', () => {
+    it(`should return error message with type as 'InvalidSyntaxError' and details as passed`, () => {
+
+      const details = `missing ')'.`;
+      const error: InvalidSyntaxError = new InvalidSyntaxError(details);
+      const expected = `InvalidSyntaxError: ${details}`;
+
+      expect(error.getErrorMessage()).toEqual(expected);
+    });
+  });
+});

--- a/src/app/logic/invalid-syntax-error.ts
+++ b/src/app/logic/invalid-syntax-error.ts
@@ -1,8 +1,9 @@
+import { PositionTracker } from './position-tracker';
 import { Error } from './error';
 
 export class InvalidSyntaxError extends Error {
 
-  constructor(details: string) {
-    super('InvalidSyntaxError', details);
+  constructor(details: string, posStart: PositionTracker, posEnd: PositionTracker) {
+    super('InvalidSyntaxError', posStart, posEnd, details);
   }
 }

--- a/src/app/logic/invalid-syntax-error.ts
+++ b/src/app/logic/invalid-syntax-error.ts
@@ -1,0 +1,8 @@
+import { Error } from './error';
+
+export class InvalidSyntaxError extends Error {
+
+  constructor(details: string) {
+    super('InvalidSyntaxError', details);
+  }
+}

--- a/src/app/logic/lexer.spec.ts
+++ b/src/app/logic/lexer.spec.ts
@@ -41,9 +41,11 @@ describe('Lexer tests', () => {
 
         const error: Array<Token> | Error = lexer.lex(sourceCode);
 
+        const posStart = new PositionTracker(0, 1, 1);
+        const posEnd = new PositionTracker(1, 1, 2);
         const expectErrorType = 'InvalidCharacterError';
         const expectErrorDetails = 'contains tabs.';
-        const expected: Error = new Error(expectErrorType, expectErrorDetails);
+        const expected: Error = new Error(expectErrorType, posStart, posEnd, expectErrorDetails);
 
         if (error instanceof Error) {
           expect(error.getErrorMessage()).toEqual(expected.getErrorMessage());
@@ -652,9 +654,11 @@ describe('Lexer tests', () => {
 
         const error: Array<Token> | Error = lexer.lex(sourceCode);
 
+        const posStart = new PositionTracker(4, 1, 5);
+        const posEnd = new PositionTracker(5, 1, 6);
         const expectErrorType = 'InvalidCharacterError';
         const expectErrorDetails = 'number has more than one decimal point.';
-        const expected: Error = new Error(expectErrorType, expectErrorDetails);
+        const expected: Error = new Error(expectErrorType, posStart, posEnd, expectErrorDetails);
 
         if (error instanceof Error) {
           expect(error.getErrorMessage()).toEqual(expected.getErrorMessage());
@@ -671,9 +675,11 @@ describe('Lexer tests', () => {
 
         const error: Array<Token> | Error = lexer.lex(sourceCode);
 
+        const posStart = new PositionTracker(2, 1, 3);
+        const posEnd = new PositionTracker(3, 1, 4);
         const expectErrorType = 'InvalidCharacterError';
         const expectErrorDetails = `can not end line statement with '='.`;
-        const expected: Error = new Error(expectErrorType, expectErrorDetails);
+        const expected: Error = new Error(expectErrorType, posStart, posEnd, expectErrorDetails);
 
         if (error instanceof Error) {
           expect(error.getErrorMessage()).toEqual(expected.getErrorMessage());
@@ -690,9 +696,11 @@ describe('Lexer tests', () => {
 
         const error: Array<Token> | Error = lexer.lex(sourceCode);
 
+        const posStart = new PositionTracker(2, 1, 3);
+        const posEnd = new PositionTracker(3, 1, 4);
         const expectErrorType = 'InvalidCharacterError';
         const expectErrorDetails = `can not end line statement with '>'.`;
-        const expected: Error = new Error(expectErrorType, expectErrorDetails);
+        const expected: Error = new Error(expectErrorType, posStart, posEnd, expectErrorDetails);
 
         if (error instanceof Error) {
           expect(error.getErrorMessage()).toEqual(expected.getErrorMessage());
@@ -709,9 +717,11 @@ describe('Lexer tests', () => {
 
         const error: Array<Token> | Error = lexer.lex(sourceCode);
 
+        const posStart = new PositionTracker(2, 1, 3);
+        const posEnd = new PositionTracker(3, 1, 4);
         const expectErrorType = 'InvalidCharacterError';
         const expectErrorDetails = `can not end line statement with '<'.`;
-        const expected: Error = new Error(expectErrorType, expectErrorDetails);
+        const expected: Error = new Error(expectErrorType, posStart, posEnd, expectErrorDetails);
 
         if (error instanceof Error) {
           expect(error.getErrorMessage()).toEqual(expected.getErrorMessage());
@@ -728,9 +738,11 @@ describe('Lexer tests', () => {
 
         const error: Array<Token> | Error = lexer.lex(sourceCode);
 
+        const posStart = new PositionTracker(1, 1, 2);
+        const posEnd = new PositionTracker(2, 1, 3);
         const expectErrorType = 'InvalidCharacterError';
         const expectErrorDetails = `the character '@' is not valid.`;
-        const expected: Error = new Error(expectErrorType, expectErrorDetails);
+        const expected: Error = new Error(expectErrorType, posStart, posEnd, expectErrorDetails);
 
         if (error instanceof Error) {
           expect(error.getErrorMessage()).toEqual(expected.getErrorMessage());

--- a/src/app/logic/lexer.spec.ts
+++ b/src/app/logic/lexer.spec.ts
@@ -1,3 +1,4 @@
+import { PositionTracker } from './position-tracker';
 import { Lexer } from './lexer';
 import { Error } from './error';
 import { Token } from '../models/token';
@@ -24,7 +25,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.NEWLINE);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.NEWLINE, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -56,7 +58,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.PLUS);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.PLUS, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -69,7 +72,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.MINUS);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.MINUS, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -82,7 +86,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.MULTIPLY);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.MULTIPLY, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -95,7 +100,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.DIVIDE);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.DIVIDE, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -108,7 +114,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.POWER);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.POWER, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -121,7 +128,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.L_BRACKET);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.L_BRACKET, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -134,7 +142,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.R_BRACKET);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.R_BRACKET, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -147,7 +156,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.COMMA);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.COMMA, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -160,7 +170,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.NUMBER, 5);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.NUMBER, posTracker, 5);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -173,7 +184,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.IDENTIFIER, 'g');
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'g');
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -188,8 +200,10 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken1: Token = createToken(TokenTypes.EQUALS);
-        const expectedToken2: Token = createToken(TokenTypes.NEWLINE);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken1: Token = createToken(TokenTypes.EQUALS, posTracker);
+        posTracker.advance();
+        const expectedToken2: Token = createToken(TokenTypes.NEWLINE, posTracker);
         const expected: Array<Token> = [expectedToken1, expectedToken2];
 
         expect(tokens).toEqual(expected);
@@ -202,7 +216,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.EQUALITY);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.EQUALITY, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -215,8 +230,10 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken1: Token = createToken(TokenTypes.G_THAN);
-        const expectedToken2: Token = createToken(TokenTypes.NEWLINE);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken1: Token = createToken(TokenTypes.G_THAN, posTracker);
+        posTracker.advance();
+        const expectedToken2: Token = createToken(TokenTypes.NEWLINE, posTracker);
         const expected: Array<Token> = [expectedToken1, expectedToken2];
 
         expect(tokens).toEqual(expected);
@@ -229,7 +246,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.G_THAN_EQ);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.G_THAN_EQ, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -242,8 +260,10 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken1: Token = createToken(TokenTypes.L_THAN);
-        const expectedToken2: Token = createToken(TokenTypes.NEWLINE);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken1: Token = createToken(TokenTypes.L_THAN, posTracker);
+        posTracker.advance();
+        const expectedToken2: Token = createToken(TokenTypes.NEWLINE, posTracker);
         const expected: Array<Token> = [expectedToken1, expectedToken2];
 
         expect(tokens).toEqual(expected);
@@ -256,7 +276,8 @@ describe('Lexer tests', () => {
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-        const expectedToken: Token = createToken(TokenTypes.L_THAN_EQ);
+        const posTracker = new PositionTracker(0, 1, 1);
+        const expectedToken: Token = createToken(TokenTypes.L_THAN_EQ, posTracker);
         const expected: Array<Token> = [expectedToken];
 
         expect(tokens).toEqual(expected);
@@ -272,12 +293,22 @@ describe('Lexer tests', () => {
 
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-          const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, 'x');
-          const expectedToken2: Token = createToken(TokenTypes.EQUALS);
-          const expectedToken3: Token = createToken(TokenTypes.NUMBER, 2);
-          const expectedToken4: Token = createToken(TokenTypes.POWER);
-          const expectedToken5: Token = createToken(TokenTypes.NUMBER, 1);
-          const expectedToken6: Token = createToken(TokenTypes.NEWLINE);
+          const posTracker = new PositionTracker(0, 1, 1);
+          const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'x');
+          posTracker.advance();
+          posTracker.advance();
+          const expectedToken2: Token = createToken(TokenTypes.EQUALS, posTracker);
+          posTracker.advance();
+          posTracker.advance();
+          const expectedToken3: Token = createToken(TokenTypes.NUMBER, posTracker, 2);
+          posTracker.advance();
+          posTracker.advance();
+          const expectedToken4: Token = createToken(TokenTypes.POWER, posTracker);
+          posTracker.advance();
+          posTracker.advance();
+          const expectedToken5: Token = createToken(TokenTypes.NUMBER, posTracker, 1);
+          posTracker.advance();
+          const expectedToken6: Token = createToken(TokenTypes.NEWLINE, posTracker);
 
           const expected: Array<Token> = [expectedToken1, expectedToken2,
                                           expectedToken3, expectedToken4,
@@ -293,10 +324,16 @@ describe('Lexer tests', () => {
 
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-          const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, 'x');
-          const expectedToken2: Token = createToken(TokenTypes.EQUALS);
-          const expectedToken3: Token = createToken(TokenTypes.NUMBER, 3.1415);
-          const expectedToken4: Token = createToken(TokenTypes.NEWLINE);
+          const posTracker = new PositionTracker(0, 1, 1);
+          const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'x');
+          posTracker.advance();
+          posTracker.advance();
+          const expectedToken2: Token = createToken(TokenTypes.EQUALS, posTracker);
+          posTracker.advance();
+          posTracker.advance();
+          const expectedToken3: Token = createToken(TokenTypes.NUMBER, posTracker, 3.1415);
+          for (let i = 0; i < 6; i++) { posTracker.advance(); }
+          const expectedToken4: Token = createToken(TokenTypes.NEWLINE, posTracker);
 
           const expected: Array<Token> = [expectedToken1, expectedToken2,
                                           expectedToken3, expectedToken4];
@@ -311,16 +348,40 @@ describe('Lexer tests', () => {
 
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-          const tokenData: Array<Array<string | any>> = [
-            [TokenTypes.IDENTIFIER, 'variable'], [TokenTypes.EQUALS],
-            [TokenTypes.IDENTIFIER, 'NOT'], [TokenTypes.L_BRACKET],
-            [TokenTypes.L_BRACKET], [TokenTypes.NUMBER, 1], [TokenTypes.G_THAN_EQ],
-            [TokenTypes.NUMBER, 2], [TokenTypes.R_BRACKET],
-            [TokenTypes.IDENTIFIER, 'AND'], [TokenTypes.L_BRACKET],
-            [TokenTypes.NUMBER, 23], [TokenTypes.L_THAN], [TokenTypes.NUMBER, 11],
-            [TokenTypes.IDENTIFIER, 'OR'], [TokenTypes.NUMBER, 0],
-            [TokenTypes.EQUALITY], [TokenTypes.NUMBER, 1], [TokenTypes.R_BRACKET],
-            [TokenTypes.R_BRACKET], [TokenTypes.NEWLINE]
+          const posTracker1 = new PositionTracker(0, 1, 1);
+          const posTracker2 = new PositionTracker(9, 1, 10);
+          const posTracker3 = new PositionTracker(11, 1, 12);
+          const posTracker4 = new PositionTracker(15, 1, 16);
+          const posTracker5 = new PositionTracker(16, 1, 17);
+          const posTracker6 = new PositionTracker(17, 1, 18);
+          const posTracker7 = new PositionTracker(19, 1, 20);
+          const posTracker8 = new PositionTracker(22, 1, 23);
+          const posTracker9 = new PositionTracker(23, 1, 24);
+          const posTracker10 = new PositionTracker(25, 1, 26);
+          const posTracker11 = new PositionTracker(29, 1, 30);
+          const posTracker12 = new PositionTracker(30, 1, 31);
+          const posTracker13 = new PositionTracker(33, 1, 34);
+          const posTracker14 = new PositionTracker(35, 1, 36);
+          const posTracker15 = new PositionTracker(38, 1, 39);
+          const posTracker16 = new PositionTracker(41, 1, 42);
+          const posTracker17 = new PositionTracker(43, 1, 44);
+          const posTracker18 = new PositionTracker(46, 1, 47);
+          const posTracker19 = new PositionTracker(47, 1, 48);
+          const posTracker20 = new PositionTracker(48, 1, 49);
+          const posTracker21 = new PositionTracker(49, 1, 50);
+
+          const tokenData: Array<[string, PositionTracker, any?]> = [
+            [TokenTypes.IDENTIFIER, posTracker1, 'variable'], [TokenTypes.EQUALS, posTracker2],
+            [TokenTypes.IDENTIFIER, posTracker3, 'NOT'], [TokenTypes.L_BRACKET, posTracker4],
+            [TokenTypes.L_BRACKET, posTracker5], [TokenTypes.NUMBER, posTracker6, 1],
+            [TokenTypes.G_THAN_EQ, posTracker7], [TokenTypes.NUMBER, posTracker8, 2],
+            [TokenTypes.R_BRACKET, posTracker9], [TokenTypes.IDENTIFIER, posTracker10, 'AND'],
+            [TokenTypes.L_BRACKET, posTracker11], [TokenTypes.NUMBER, posTracker12, 23],
+            [TokenTypes.L_THAN, posTracker13], [TokenTypes.NUMBER, posTracker14, 11],
+            [TokenTypes.IDENTIFIER, posTracker15, 'OR'], [TokenTypes.NUMBER, posTracker16, 0],
+            [TokenTypes.EQUALITY, posTracker17], [TokenTypes.NUMBER, posTracker18, 1],
+            [TokenTypes.R_BRACKET, posTracker19], [TokenTypes.R_BRACKET, posTracker20],
+            [TokenTypes.NEWLINE, posTracker21]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
@@ -332,21 +393,46 @@ describe('Lexer tests', () => {
       describe('If/else statement tokens tests', () => {
         it('should return list of correct tokens for source code with if/else statement', () => {
 
-          const sourceCode: string = 'if (10 > 1 AND TRUE) then\n  x = 1\nelse\n  x = 2\nend\n';
+          const sourceCode: string = 'if (10 > 1 AND TRUE) then\nx = 1\nelse\nx = 2\nend\n';
           const lexer: Lexer = new Lexer();
 
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-          const tokenData: Array<Array<string | any>> = [
-            [TokenTypes.IDENTIFIER, 'if'], [TokenTypes.L_BRACKET],
-            [TokenTypes.NUMBER, 10], [TokenTypes.G_THAN], [TokenTypes.NUMBER, 1],
-            [TokenTypes.IDENTIFIER, 'AND'], [TokenTypes.IDENTIFIER, 'TRUE'],
-            [TokenTypes.R_BRACKET], [TokenTypes.IDENTIFIER, 'then'],
-            [TokenTypes.NEWLINE], [TokenTypes.IDENTIFIER, 'x'], [TokenTypes.EQUALS],
-            [TokenTypes.NUMBER, 1], [TokenTypes.NEWLINE],
-            [TokenTypes.IDENTIFIER, 'else'], [TokenTypes.NEWLINE],
-            [TokenTypes.IDENTIFIER, 'x'], [TokenTypes.EQUALS], [TokenTypes.NUMBER, 2],
-            [TokenTypes.NEWLINE], [TokenTypes.IDENTIFIER, 'end'], [TokenTypes.NEWLINE]
+          const posTracker1 = new PositionTracker(0, 1, 1); // if
+          const posTracker2 = new PositionTracker(3, 1, 4); // (
+          const posTracker3 = new PositionTracker(4, 1, 5); // 10
+          const posTracker4 = new PositionTracker(7, 1, 8); // >
+          const posTracker5 = new PositionTracker(9, 1, 10); // 1
+          const posTracker6 = new PositionTracker(11, 1, 12); // AND
+          const posTracker7 = new PositionTracker(15, 1, 16); // TRUE
+          const posTracker8 = new PositionTracker(19, 1, 20); // )
+          const posTracker9 = new PositionTracker(21, 1, 22); // then
+          const posTracker10 = new PositionTracker(25, 1, 26); // \n
+          const posTracker11 = new PositionTracker(26, 2, 1); // x
+          const posTracker12 = new PositionTracker(28, 2, 3); // =
+          const posTracker13 = new PositionTracker(30, 2, 5); // 1
+          const posTracker14 = new PositionTracker(31, 2, 6); // \n
+          const posTracker15 = new PositionTracker(32, 3, 1); // else
+          const posTracker16 = new PositionTracker(36, 3, 5); // \n
+          const posTracker17 = new PositionTracker(37, 4, 1); // x
+          const posTracker18 = new PositionTracker(39, 4, 3); // =
+          const posTracker19 = new PositionTracker(41, 4, 5); // 2
+          const posTracker20 = new PositionTracker(42, 4, 6); // \n
+          const posTracker21 = new PositionTracker(43, 5, 1); // end
+          const posTracker22 = new PositionTracker(46, 5, 4); // \n
+
+          const tokenData: Array<[string, PositionTracker, any?]> = [
+            [TokenTypes.IDENTIFIER, posTracker1, 'if'], [TokenTypes.L_BRACKET, posTracker2],
+            [TokenTypes.NUMBER, posTracker3, 10], [TokenTypes.G_THAN, posTracker4],
+            [TokenTypes.NUMBER, posTracker5, 1], [TokenTypes.IDENTIFIER, posTracker6, 'AND'],
+            [TokenTypes.IDENTIFIER, posTracker7, 'TRUE'], [TokenTypes.R_BRACKET, posTracker8],
+            [TokenTypes.IDENTIFIER, posTracker9, 'then'], [TokenTypes.NEWLINE, posTracker10],
+            [TokenTypes.IDENTIFIER, posTracker11, 'x'], [TokenTypes.EQUALS, posTracker12],
+            [TokenTypes.NUMBER, posTracker13, 1], [TokenTypes.NEWLINE, posTracker14],
+            [TokenTypes.IDENTIFIER, posTracker15, 'else'], [TokenTypes.NEWLINE, posTracker16],
+            [TokenTypes.IDENTIFIER, posTracker17, 'x'], [TokenTypes.EQUALS, posTracker18],
+            [TokenTypes.NUMBER, posTracker19, 2], [TokenTypes.NEWLINE, posTracker20],
+            [TokenTypes.IDENTIFIER, posTracker21, 'end'], [TokenTypes.NEWLINE, posTracker22]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
@@ -358,22 +444,46 @@ describe('Lexer tests', () => {
       describe('For/while loop tokens test', () => {
         it('should return list of correct tokens for source code with for loop', () => {
 
-          const sourceCode: string = 'x = 1\nfor (i = 1 to 10) loop\n  x = x * i\nend\n';
+          const sourceCode: string = 'x = 1\nfor (i = 1 to 10) loop\nx = x * i\nend\n';
           const lexer: Lexer = new Lexer();
 
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-          const tokenData: Array<Array<string | any>> = [
-            [TokenTypes.IDENTIFIER, 'x'], [TokenTypes.EQUALS], [TokenTypes.NUMBER, 1],
-            [TokenTypes.NEWLINE], [TokenTypes.IDENTIFIER, 'for'],
-            [TokenTypes.L_BRACKET], [TokenTypes.IDENTIFIER, 'i'], [TokenTypes.EQUALS],
-            [TokenTypes.NUMBER, 1], [TokenTypes.IDENTIFIER, 'to'],
-            [TokenTypes.NUMBER, 10], [TokenTypes.R_BRACKET],
-            [TokenTypes.IDENTIFIER, 'loop'], [TokenTypes.NEWLINE],
-            [TokenTypes.IDENTIFIER, 'x'], [TokenTypes.EQUALS],
-            [TokenTypes.IDENTIFIER, 'x'], [TokenTypes.MULTIPLY],
-            [TokenTypes.IDENTIFIER, 'i'], [TokenTypes.NEWLINE],
-            [TokenTypes.IDENTIFIER, 'end'], [TokenTypes.NEWLINE]
+          const posTracker1 = new PositionTracker(0, 1, 1);
+          const posTracker2 = new PositionTracker(2, 1, 3);
+          const posTracker3 = new PositionTracker(4, 1, 5);
+          const posTracker4 = new PositionTracker(5, 1, 6);
+          const posTracker5 = new PositionTracker(6, 2, 1);
+          const posTracker6 = new PositionTracker(10, 2, 5);
+          const posTracker7 = new PositionTracker(11, 2, 6);
+          const posTracker8 = new PositionTracker(13, 2, 8);
+          const posTracker9 = new PositionTracker(15, 2, 10);
+          const posTracker10 = new PositionTracker(17, 2, 12);
+          const posTracker11 = new PositionTracker(20, 2, 15);
+          const posTracker12 = new PositionTracker(22, 2, 17);
+          const posTracker13 = new PositionTracker(24, 2, 19);
+          const posTracker14 = new PositionTracker(28, 2, 23);
+          const posTracker15 = new PositionTracker(29, 3, 1);
+          const posTracker16 = new PositionTracker(31, 3, 3);
+          const posTracker17 = new PositionTracker(33, 3, 5);
+          const posTracker18 = new PositionTracker(35, 3, 7);
+          const posTracker19 = new PositionTracker(37, 3, 9);
+          const posTracker20 = new PositionTracker(38, 3, 10);
+          const posTracker21 = new PositionTracker(39, 4, 1);
+          const posTracker22 = new PositionTracker(42, 4, 4);
+
+          const tokenData: Array<[string, PositionTracker, any?]> = [
+            [TokenTypes.IDENTIFIER, posTracker1, 'x'], [TokenTypes.EQUALS, posTracker2],
+            [TokenTypes.NUMBER, posTracker3, 1], [TokenTypes.NEWLINE, posTracker4],
+            [TokenTypes.IDENTIFIER, posTracker5, 'for'], [TokenTypes.L_BRACKET, posTracker6],
+            [TokenTypes.IDENTIFIER, posTracker7, 'i'], [TokenTypes.EQUALS, posTracker8],
+            [TokenTypes.NUMBER, posTracker9, 1], [TokenTypes.IDENTIFIER, posTracker10, 'to'],
+            [TokenTypes.NUMBER, posTracker11, 10], [TokenTypes.R_BRACKET, posTracker12],
+            [TokenTypes.IDENTIFIER, posTracker13, 'loop'], [TokenTypes.NEWLINE, posTracker14],
+            [TokenTypes.IDENTIFIER, posTracker15, 'x'], [TokenTypes.EQUALS, posTracker16],
+            [TokenTypes.IDENTIFIER, posTracker17, 'x'], [TokenTypes.MULTIPLY, posTracker18],
+            [TokenTypes.IDENTIFIER, posTracker19, 'i'], [TokenTypes.NEWLINE, posTracker20],
+            [TokenTypes.IDENTIFIER, posTracker21, 'end'], [TokenTypes.NEWLINE, posTracker22]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
@@ -383,22 +493,49 @@ describe('Lexer tests', () => {
 
         it('should return list of correct tokens for source code with while loop', () => {
 
-          const sourceCode: string = 'x = 10\ni = 1\nwhile (i < x) loop\n  i = i + 1\nend\n';
+          const sourceCode: string = 'x = 10\ni = 1\nwhile (i < x) loop\ni = i + 1\nend\n';
           const lexer: Lexer = new Lexer();
 
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-          const tokenData: Array<Array<string | any>> = [
-            [TokenTypes.IDENTIFIER, 'x'], [TokenTypes.EQUALS], [TokenTypes.NUMBER, 10],
-            [TokenTypes.NEWLINE], [TokenTypes.IDENTIFIER, 'i'],
-            [TokenTypes.EQUALS], [TokenTypes.NUMBER, 1], [TokenTypes.NEWLINE],
-            [TokenTypes.IDENTIFIER, 'while'], [TokenTypes.L_BRACKET],
-            [TokenTypes.IDENTIFIER, 'i'], [TokenTypes.L_THAN],
-            [TokenTypes.IDENTIFIER, 'x'], [TokenTypes.R_BRACKET],
-            [TokenTypes.IDENTIFIER, 'loop'], [TokenTypes.NEWLINE],
-            [TokenTypes.IDENTIFIER, 'i'], [TokenTypes.EQUALS],
-            [TokenTypes.IDENTIFIER, 'i'], [TokenTypes.PLUS], [TokenTypes.NUMBER, 1],
-            [TokenTypes.NEWLINE], [TokenTypes.IDENTIFIER, 'end'], [TokenTypes.NEWLINE]
+          const posTracker1 = new PositionTracker(0, 1, 1);
+          const posTracker2 = new PositionTracker(2, 1, 3);
+          const posTracker3 = new PositionTracker(4, 1, 5);
+          const posTracker4 = new PositionTracker(6, 1, 7);
+          const posTracker5 = new PositionTracker(7, 2, 1);
+          const posTracker6 = new PositionTracker(9, 2, 3);
+          const posTracker7 = new PositionTracker(11, 2, 5);
+          const posTracker8 = new PositionTracker(12, 2, 6);
+          const posTracker9 = new PositionTracker(13, 3, 1);
+          const posTracker10 = new PositionTracker(19, 3, 7);
+          const posTracker11 = new PositionTracker(20, 3, 8);
+          const posTracker12 = new PositionTracker(22, 3, 10);
+          const posTracker13 = new PositionTracker(24, 3, 12);
+          const posTracker14 = new PositionTracker(25, 3, 13);
+          const posTracker15 = new PositionTracker(27, 3, 15);
+          const posTracker16 = new PositionTracker(31, 3, 19);
+          const posTracker17 = new PositionTracker(32, 4, 1);
+          const posTracker18 = new PositionTracker(34, 4, 3);
+          const posTracker19 = new PositionTracker(36, 4, 5);
+          const posTracker20 = new PositionTracker(38, 4, 7);
+          const posTracker21 = new PositionTracker(40, 4, 9);
+          const posTracker22 = new PositionTracker(41, 4, 10);
+          const posTracker23 = new PositionTracker(42, 5, 1);
+          const posTracker24 = new PositionTracker(45, 5, 4);
+
+          const tokenData: Array<[string, PositionTracker, any?]> = [
+            [TokenTypes.IDENTIFIER, posTracker1, 'x'], [TokenTypes.EQUALS, posTracker2],
+            [TokenTypes.NUMBER, posTracker3, 10], [TokenTypes.NEWLINE, posTracker4],
+            [TokenTypes.IDENTIFIER, posTracker5, 'i'], [TokenTypes.EQUALS, posTracker6],
+            [TokenTypes.NUMBER, posTracker7, 1], [TokenTypes.NEWLINE, posTracker8],
+            [TokenTypes.IDENTIFIER, posTracker9, 'while'], [TokenTypes.L_BRACKET, posTracker10],
+            [TokenTypes.IDENTIFIER, posTracker11, 'i'], [TokenTypes.L_THAN, posTracker12],
+            [TokenTypes.IDENTIFIER, posTracker13, 'x'], [TokenTypes.R_BRACKET, posTracker14],
+            [TokenTypes.IDENTIFIER, posTracker15, 'loop'], [TokenTypes.NEWLINE, posTracker16],
+            [TokenTypes.IDENTIFIER, posTracker17, 'i'], [TokenTypes.EQUALS, posTracker18],
+            [TokenTypes.IDENTIFIER, posTracker19, 'i'], [TokenTypes.PLUS, posTracker20],
+            [TokenTypes.NUMBER, posTracker21, 1], [TokenTypes.NEWLINE, posTracker22],
+            [TokenTypes.IDENTIFIER, posTracker23, 'end'], [TokenTypes.NEWLINE, posTracker24]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
@@ -410,24 +547,42 @@ describe('Lexer tests', () => {
       describe('Function calls/definitions token tests', () => {
         it('should return list of correct tokens for source code with function definition', () => {
 
-          const sourceCode: string = 'function add(x, y) begin\n  return x + y\nend\n';
+          const sourceCode: string = 'function add(x, y) begin\nreturn x + y\nend\n';
           const lexer: Lexer = new Lexer();
 
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-          const tokenData: Array<Array<string | any>> = [
-            [TokenTypes.IDENTIFIER, 'function'], [TokenTypes.IDENTIFIER, 'add'],
-            [TokenTypes.L_BRACKET], [TokenTypes.IDENTIFIER, 'x'],
-            [TokenTypes.COMMA], [TokenTypes.IDENTIFIER, 'y'], [TokenTypes.R_BRACKET],
-            [TokenTypes.IDENTIFIER, 'begin'], [TokenTypes.NEWLINE],
-            [TokenTypes.IDENTIFIER, 'return'], [TokenTypes.IDENTIFIER, 'x'],
-            [TokenTypes.PLUS], [TokenTypes.IDENTIFIER, 'y'], [TokenTypes.NEWLINE],
-            [TokenTypes.IDENTIFIER, 'end'], [TokenTypes.NEWLINE]
+          const posTracker1 = new PositionTracker(0, 1, 1);
+          const posTracker2 = new PositionTracker(9, 1, 10);
+          const posTracker3 = new PositionTracker(12, 1, 13);
+          const posTracker4 = new PositionTracker(13, 1, 14);
+          const posTracker5 = new PositionTracker(14, 1, 15);
+          const posTracker6 = new PositionTracker(16, 1, 17);
+          const posTracker7 = new PositionTracker(17, 1, 18);
+          const posTracker8 = new PositionTracker(19, 1, 20);
+          const posTracker9 = new PositionTracker(24, 1, 25);
+          const posTracker10 = new PositionTracker(25, 2, 1);
+          const posTracker11 = new PositionTracker(32, 2, 8);
+          const posTracker12 = new PositionTracker(34, 2, 10);
+          const posTracker13 = new PositionTracker(36, 2, 12);
+          const posTracker14 = new PositionTracker(37, 2, 13);
+          const posTracker15 = new PositionTracker(38, 3, 1);
+          const posTracker16 = new PositionTracker(41, 3, 4);
+
+          const tokenData: Array<[string, PositionTracker, any?]> = [
+            [TokenTypes.IDENTIFIER, posTracker1, 'function'],
+            [TokenTypes.IDENTIFIER, posTracker2, 'add'], [TokenTypes.L_BRACKET, posTracker3],
+            [TokenTypes.IDENTIFIER, posTracker4, 'x'], [TokenTypes.COMMA, posTracker5],
+            [TokenTypes.IDENTIFIER, posTracker6, 'y'], [TokenTypes.R_BRACKET, posTracker7],
+            [TokenTypes.IDENTIFIER, posTracker8, 'begin'], [TokenTypes.NEWLINE, posTracker9],
+            [TokenTypes.IDENTIFIER, posTracker10, 'return'],
+            [TokenTypes.IDENTIFIER, posTracker11, 'x'], [TokenTypes.PLUS, posTracker12],
+            [TokenTypes.IDENTIFIER, posTracker13, 'y'], [TokenTypes.NEWLINE, posTracker14],
+            [TokenTypes.IDENTIFIER, posTracker15, 'end'], [TokenTypes.NEWLINE, posTracker16]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
-          console.log(tokens);
-          console.log(expected);
+
           expect(tokens).toEqual(expected);
         });
 
@@ -438,11 +593,17 @@ describe('Lexer tests', () => {
 
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
-          const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, 'output');
-          const expectedToken2: Token = createToken(TokenTypes.L_BRACKET);
-          const expectedToken3: Token = createToken(TokenTypes.NUMBER, 10);
-          const expectedToken4: Token = createToken(TokenTypes.R_BRACKET);
-          const expectedToken5: Token = createToken(TokenTypes.NEWLINE);
+          const posTracker = new PositionTracker(0, 1, 1);
+          const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'output');
+          for (let i = 0; i < 6; i++) { posTracker.advance(); }
+          const expectedToken2: Token = createToken(TokenTypes.L_BRACKET, posTracker);
+          posTracker.advance();
+          const expectedToken3: Token = createToken(TokenTypes.NUMBER, posTracker, 10);
+          posTracker.advance();
+          posTracker.advance();
+          const expectedToken4: Token = createToken(TokenTypes.R_BRACKET, posTracker);
+          posTracker.advance();
+          const expectedToken5: Token = createToken(TokenTypes.NEWLINE, posTracker);
 
           const expected: Array<Token> = [expectedToken1, expectedToken2,
                                           expectedToken3, expectedToken4,
@@ -553,18 +714,26 @@ describe('Lexer tests', () => {
 });
 
 // Utility functions.
-function createToken(type: string, value?: any): Token {
+function createToken(type: string, posStart: PositionTracker, value?: any): Token {
 
   let token: Token;
 
+  const posStartNew = posStart.copy();
+  let posEnd = posStart.copy();
+  posEnd.advance();
+
   if (value === undefined) {
     token = {
-      type: type
+      type: type,
+      positionStart: posStartNew,
+      positionEnd: posEnd
     };
   }
   else {
     token = {
       type: type,
+      positionStart: posStartNew,
+      positionEnd: posEnd,
       value: value
     };
   }
@@ -572,18 +741,18 @@ function createToken(type: string, value?: any): Token {
   return token;
 }
 
-function createTokenArray(tokenData: Array<Array<string | any>>): Array<Token> {
+function createTokenArray(tokenData: Array<[string, PositionTracker, any?]>): Array<Token> {
 
   let tokens: Array<Token> = [];
 
   for (let data of tokenData) {
     let token: Token;
 
-    if (data.length === 1) {
-      token = createToken(data[0]);
+    if (data.length === 2) {
+      token = createToken(data[0], data[1]);
     }
     else {
-      token = createToken(data[0], data[1]);
+      token = createToken(data[0], data[1], data[2]);
     }
 
     tokens.push(token);

--- a/src/app/logic/lexer.spec.ts
+++ b/src/app/logic/lexer.spec.ts
@@ -13,7 +13,8 @@ describe('Lexer tests', () => {
         const lexer: Lexer = new Lexer();
 
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
-        const expected: Array<Token> = [];
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
+        const expected: Array<Token> = [eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -26,8 +27,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 2, 1));
         const expectedToken: Token = createToken(TokenTypes.NEWLINE, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -59,8 +61,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.PLUS, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -73,8 +76,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.MINUS, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -87,8 +91,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.MULTIPLY, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -101,8 +106,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.DIVIDE, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -115,8 +121,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.POWER, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -129,8 +136,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.L_BRACKET, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -143,8 +151,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.R_BRACKET, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -157,8 +166,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.COMMA, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -171,8 +181,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.NUMBER, posTracker, 5);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -185,8 +196,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(1, 1, 2));
         const expectedToken: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'g');
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -201,10 +213,11 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(2, 2, 1));
         const expectedToken1: Token = createToken(TokenTypes.EQUALS, posTracker);
         posTracker.advance();
         const expectedToken2: Token = createToken(TokenTypes.NEWLINE, posTracker);
-        const expected: Array<Token> = [expectedToken1, expectedToken2];
+        const expected: Array<Token> = [expectedToken1, expectedToken2, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -217,8 +230,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(2, 1, 3));
         const expectedToken: Token = createToken(TokenTypes.EQUALITY, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -231,10 +245,11 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(2, 2, 1));
         const expectedToken1: Token = createToken(TokenTypes.G_THAN, posTracker);
         posTracker.advance();
         const expectedToken2: Token = createToken(TokenTypes.NEWLINE, posTracker);
-        const expected: Array<Token> = [expectedToken1, expectedToken2];
+        const expected: Array<Token> = [expectedToken1, expectedToken2, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -247,8 +262,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(2, 1, 3));
         const expectedToken: Token = createToken(TokenTypes.G_THAN_EQ, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -261,10 +277,11 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(2, 2, 1));
         const expectedToken1: Token = createToken(TokenTypes.L_THAN, posTracker);
         posTracker.advance();
         const expectedToken2: Token = createToken(TokenTypes.NEWLINE, posTracker);
-        const expected: Array<Token> = [expectedToken1, expectedToken2];
+        const expected: Array<Token> = [expectedToken1, expectedToken2, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -277,8 +294,9 @@ describe('Lexer tests', () => {
         const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
         const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(2, 1, 3));
         const expectedToken: Token = createToken(TokenTypes.L_THAN_EQ, posTracker);
-        const expected: Array<Token> = [expectedToken];
+        const expected: Array<Token> = [expectedToken, eofToken];
 
         expect(tokens).toEqual(expected);
       });
@@ -294,6 +312,7 @@ describe('Lexer tests', () => {
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
           const posTracker = new PositionTracker(0, 1, 1);
+          const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(10, 2, 1));
           const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'x');
           posTracker.advance();
           posTracker.advance();
@@ -310,9 +329,9 @@ describe('Lexer tests', () => {
           posTracker.advance();
           const expectedToken6: Token = createToken(TokenTypes.NEWLINE, posTracker);
 
-          const expected: Array<Token> = [expectedToken1, expectedToken2,
-                                          expectedToken3, expectedToken4,
-                                          expectedToken5, expectedToken6];
+          const expected: Array<Token> = [expectedToken1, expectedToken2, expectedToken3,
+                                          expectedToken4, expectedToken5, expectedToken6,
+                                          eofToken];
 
           expect(tokens).toEqual(expected);
         });
@@ -325,6 +344,7 @@ describe('Lexer tests', () => {
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
           const posTracker = new PositionTracker(0, 1, 1);
+          const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(11, 2, 1));
           const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'x');
           posTracker.advance();
           posTracker.advance();
@@ -335,8 +355,8 @@ describe('Lexer tests', () => {
           for (let i = 0; i < 6; i++) { posTracker.advance(); }
           const expectedToken4: Token = createToken(TokenTypes.NEWLINE, posTracker);
 
-          const expected: Array<Token> = [expectedToken1, expectedToken2,
-                                          expectedToken3, expectedToken4];
+          const expected: Array<Token> = [expectedToken1, expectedToken2, expectedToken3,
+                                          expectedToken4, eofToken];
 
           expect(tokens).toEqual(expected);
         });
@@ -369,6 +389,7 @@ describe('Lexer tests', () => {
           const posTracker19 = new PositionTracker(47, 1, 48);
           const posTracker20 = new PositionTracker(48, 1, 49);
           const posTracker21 = new PositionTracker(49, 1, 50);
+          const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(50, 2, 1));
 
           const tokenData: Array<[string, PositionTracker, any?]> = [
             [TokenTypes.IDENTIFIER, posTracker1, 'variable'], [TokenTypes.EQUALS, posTracker2],
@@ -385,6 +406,7 @@ describe('Lexer tests', () => {
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
+          expected.push(eofToken);
 
           expect(tokens).toEqual(expected);
         });
@@ -420,6 +442,7 @@ describe('Lexer tests', () => {
           const posTracker20 = new PositionTracker(42, 4, 6); // \n
           const posTracker21 = new PositionTracker(43, 5, 1); // end
           const posTracker22 = new PositionTracker(46, 5, 4); // \n
+          const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(47, 6, 1));
 
           const tokenData: Array<[string, PositionTracker, any?]> = [
             [TokenTypes.IDENTIFIER, posTracker1, 'if'], [TokenTypes.L_BRACKET, posTracker2],
@@ -436,6 +459,7 @@ describe('Lexer tests', () => {
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
+          expected.push(eofToken);
 
           expect(tokens).toEqual(expected);
         });
@@ -471,6 +495,7 @@ describe('Lexer tests', () => {
           const posTracker20 = new PositionTracker(38, 3, 10);
           const posTracker21 = new PositionTracker(39, 4, 1);
           const posTracker22 = new PositionTracker(42, 4, 4);
+          const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(43, 5, 1));
 
           const tokenData: Array<[string, PositionTracker, any?]> = [
             [TokenTypes.IDENTIFIER, posTracker1, 'x'], [TokenTypes.EQUALS, posTracker2],
@@ -487,6 +512,7 @@ describe('Lexer tests', () => {
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
+          expected.push(eofToken);
 
           expect(tokens).toEqual(expected);
         });
@@ -522,6 +548,7 @@ describe('Lexer tests', () => {
           const posTracker22 = new PositionTracker(41, 4, 10);
           const posTracker23 = new PositionTracker(42, 5, 1);
           const posTracker24 = new PositionTracker(45, 5, 4);
+          const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(46, 6, 1));
 
           const tokenData: Array<[string, PositionTracker, any?]> = [
             [TokenTypes.IDENTIFIER, posTracker1, 'x'], [TokenTypes.EQUALS, posTracker2],
@@ -539,6 +566,7 @@ describe('Lexer tests', () => {
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
+          expected.push(eofToken);
 
           expect(tokens).toEqual(expected);
         });
@@ -568,6 +596,7 @@ describe('Lexer tests', () => {
           const posTracker14 = new PositionTracker(37, 2, 13);
           const posTracker15 = new PositionTracker(38, 3, 1);
           const posTracker16 = new PositionTracker(41, 3, 4);
+          const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(42, 4, 1));
 
           const tokenData: Array<[string, PositionTracker, any?]> = [
             [TokenTypes.IDENTIFIER, posTracker1, 'function'],
@@ -582,6 +611,7 @@ describe('Lexer tests', () => {
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
+          expected.push(eofToken);
 
           expect(tokens).toEqual(expected);
         });
@@ -594,6 +624,7 @@ describe('Lexer tests', () => {
           const tokens: Array<Token> | Error = lexer.lex(sourceCode);
 
           const posTracker = new PositionTracker(0, 1, 1);
+          const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(11, 2, 1));
           const expectedToken1: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'output');
           for (let i = 0; i < 6; i++) { posTracker.advance(); }
           const expectedToken2: Token = createToken(TokenTypes.L_BRACKET, posTracker);
@@ -605,9 +636,8 @@ describe('Lexer tests', () => {
           posTracker.advance();
           const expectedToken5: Token = createToken(TokenTypes.NEWLINE, posTracker);
 
-          const expected: Array<Token> = [expectedToken1, expectedToken2,
-                                          expectedToken3, expectedToken4,
-                                          expectedToken5];
+          const expected: Array<Token> = [expectedToken1, expectedToken2, expectedToken3,
+                                          expectedToken4, expectedToken5, eofToken];
 
           expect(tokens).toEqual(expected);
         });

--- a/src/app/logic/lexer.ts
+++ b/src/app/logic/lexer.ts
@@ -63,6 +63,9 @@ export class Lexer {
       }
     }
 
+    const eofToken: Token = this.createToken(TokenTypes.EOF, this.positionTracker);
+    tokens.push(eofToken);
+
     return tokens;
   }
 

--- a/src/app/logic/parse-result.spec.ts
+++ b/src/app/logic/parse-result.spec.ts
@@ -1,0 +1,94 @@
+import { PositionTracker } from './position-tracker';
+import { ASTNode } from './../models/ast-node';
+import { ParseResult } from './parse-result';
+import { InvalidSyntaxError } from './invalid-syntax-error';
+import { Token } from '../models/token';
+import { EQUALS } from './token-type.constants';
+
+describe('ParseResult tests', () => {
+  it('should initialise node and error attributes as null', () => {
+    const parseResult = new ParseResult();
+
+    expect(parseResult.getError()).toEqual(null);
+    expect(parseResult.getNode()).toEqual(null);
+  });
+
+  describe('success tests', () => {
+    it('should return a node instance and null error when using getter, after calling success', () => {
+      const astNode: ASTNode = createASTNode(EQUALS);
+      const parseResult = new ParseResult();
+
+      parseResult.success(astNode);
+
+      expect(parseResult.getNode()).toEqual(astNode);
+      expect(parseResult.getError()).toEqual(null);
+    });
+  });
+
+  describe('failure tests', () => {
+    it('should return an error instance and null node when using getter, after calling failure', () => {
+      const syntaxError = new InvalidSyntaxError(`missing ')'`);
+      const parseResult = new ParseResult();
+
+      parseResult.failure(syntaxError);
+
+      expect(parseResult.getError()).toEqual(syntaxError);
+      expect(parseResult.getNode()).toEqual(null);
+    });
+  });
+
+  describe('register tests', () => {
+    it('should return passed node arg and keep node and error attributes null', () => {
+      const astNode: ASTNode = createASTNode(EQUALS);
+      const parseResult = new ParseResult();
+
+      const returnedNode: ASTNode = parseResult.register(astNode);
+
+      expect(returnedNode).toEqual(astNode);
+      expect(parseResult.getNode()).toEqual(null);
+      expect(parseResult.getError()).toEqual(null);
+    });
+
+    it('should return node in passed in parse result and assign error if error exists in passed parse result', () => {
+      const syntaxError = new InvalidSyntaxError(`missing ')'`);
+      const errorParseResult = new ParseResult();
+      errorParseResult.failure(syntaxError);
+
+      const parseResult = new ParseResult();
+      const returnedNode: ASTNode = parseResult.register(errorParseResult);
+
+      expect(returnedNode).toEqual(errorParseResult.getNode());
+      expect(parseResult.getNode()).toEqual(null);
+      expect(parseResult.getError()).toEqual(syntaxError);
+    });
+
+    it('should return node in passed in parse result and assign node if node exists in passed parse result', () => {
+      const astNode: ASTNode = createASTNode(EQUALS);
+      const nodeParseResult = new ParseResult();
+      nodeParseResult.success(astNode);
+
+      const parseResult = new ParseResult();
+      const returnedNode: ASTNode = parseResult.register(nodeParseResult);
+
+      expect(returnedNode).toEqual(astNode);
+      expect(parseResult.getNode()).toEqual(null);
+      expect(parseResult.getError()).toEqual(null);
+    });
+  });
+});
+
+function createASTNode(tokenType: string): ASTNode {
+  const startPos = new PositionTracker(0, 1, 1);
+  const endPos = startPos.copy();
+  endPos.advance();
+
+  const equalsToken: Token = {
+    type: tokenType,
+    positionStart: startPos,
+    positionEnd: endPos
+  };
+
+  const astNode: ASTNode = { token: equalsToken };
+
+  return astNode;
+}

--- a/src/app/logic/parse-result.spec.ts
+++ b/src/app/logic/parse-result.spec.ts
@@ -27,7 +27,9 @@ describe('ParseResult tests', () => {
 
   describe('failure tests', () => {
     it('should return an error instance and null node when using getter, after calling failure', () => {
-      const syntaxError = new InvalidSyntaxError(`missing ')'`);
+      const posStart = new PositionTracker(4, 1, 5);
+      const posEnd = new PositionTracker(5, 1, 6);
+      const syntaxError = new InvalidSyntaxError(`missing ')'`, posStart, posEnd);
       const parseResult = new ParseResult();
 
       parseResult.failure(syntaxError);
@@ -50,7 +52,9 @@ describe('ParseResult tests', () => {
     });
 
     it('should return node in passed in parse result and assign error if error exists in passed parse result', () => {
-      const syntaxError = new InvalidSyntaxError(`missing ')'`);
+      const posStart = new PositionTracker(4, 1, 5);
+      const posEnd = new PositionTracker(5, 1, 6);
+      const syntaxError = new InvalidSyntaxError(`missing ')'`, posStart, posEnd);
       const errorParseResult = new ParseResult();
       errorParseResult.failure(syntaxError);
 

--- a/src/app/logic/parse-result.ts
+++ b/src/app/logic/parse-result.ts
@@ -1,0 +1,49 @@
+import { ASTNode } from './../models/ast-node';
+import { InvalidSyntaxError } from './invalid-syntax-error';
+import { Token } from '../models/token';
+
+/**
+ * Groups information about the node and error at a particular parse step, when forming the AST.
+ */
+export class ParseResult {
+
+  private error: InvalidSyntaxError;
+  private node: ASTNode;
+
+  constructor() {
+    this.error = null;
+    this.node = null;
+  }
+
+  /**
+   * This method records any noticed errors in the passed in ParseResult and also returns the
+   * AST node value.
+   * @param result The result of a parse step to be checked for errors.
+   * @returns Returns the node of the AST at that parse step.
+   */
+  public register(result: ParseResult | ASTNode | Token): ASTNode {
+    if (result instanceof ParseResult) {
+      if (result.getError() !== null) { this.error = result.getError(); }
+      return result.getNode();
+    }
+
+    // if result is an ASTNode (based on if it has a token)
+    if ((<ASTNode>result).token) { return <ASTNode>result; }
+
+    return null; // Tokens should return null;
+  }
+
+  public success(node: ASTNode): ParseResult {
+    this.node = node;
+    return this;
+  }
+
+  public failure(error: InvalidSyntaxError): ParseResult {
+    this.error = error;
+    return this;
+  }
+
+  public getError(): InvalidSyntaxError { return this.error; }
+
+  public getNode(): ASTNode { return this.node; }
+}

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -1,0 +1,487 @@
+import { InvalidSyntaxError } from './invalid-syntax-error';
+import { ASTNode } from '../models/ast-node';
+import { Parser } from './parser';
+import { PositionTracker } from './position-tracker';
+import { Token } from '../models/token';
+import { NUMBER, EOF, MINUS, PLUS, MULTIPLY, DIVIDE, L_BRACKET, R_BRACKET } from './token-type.constants';
+import { ParseResult } from './parse-result';
+
+describe('Parser tests', () => {
+  describe('parse tests', () => {
+    describe('arithmetic expression tests', () => {
+      it('should return a single number node result with one number in token list', () => {
+        const posStart = new PositionTracker(0, 1, 1);
+        const posStartEof = new PositionTracker(2, 1, 3);
+
+        const tokenList: Array<Token> = [createToken(NUMBER, posStart, 10),
+                                        createToken(EOF, posStartEof)];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode: ASTNode = { token: createToken(NUMBER, posStart, 10) };
+        let expected = new ParseResult();
+        expected = expected.success(numberNode);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return a single number node result with one decimal number in token list', () => {
+        const posStart = new PositionTracker(0, 1, 1);
+        const posStartEof = new PositionTracker(2, 1, 3);
+
+        const tokenList: Array<Token> = [createToken(NUMBER, posStart, 3.14),
+                                        createToken(EOF, posStartEof)];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode: ASTNode = { token: createToken(NUMBER, posStart, 3.14) };
+        let expected = new ParseResult();
+        expected = expected.success(numberNode);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for unary operation expression: -1', () => {
+        const posStartMinus = new PositionTracker(0, 1, 1);
+        const posStartNumber = new PositionTracker(1, 1, 2);
+        const posStartEof = new PositionTracker(2, 1, 3);
+
+        const tokenList: Array<Token> = [
+          createToken(MINUS, posStartMinus), createToken(NUMBER, posStartNumber, 1),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode: ASTNode = { token: createToken(NUMBER, posStartNumber, 1) };
+        const unaryNode: ASTNode = { token: createToken(MINUS, posStartMinus), node: numberNode };
+        let expected = new ParseResult();
+        expected = expected.success(unaryNode);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for unary operation expression: +1', () => {
+        const posStartPlus = new PositionTracker(0, 1, 1);
+        const posStartNumber = new PositionTracker(1, 1, 2);
+        const posStartEof = new PositionTracker(2, 1, 3);
+
+        const tokenList: Array<Token> = [
+          createToken(PLUS, posStartPlus), createToken(NUMBER, posStartNumber, 1),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode: ASTNode = { token: createToken(NUMBER, posStartNumber, 1) };
+        const unaryNode: ASTNode = { token: createToken(PLUS, posStartPlus), node: numberNode };
+        let expected = new ParseResult();
+        expected = expected.success(unaryNode);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for binary operation expression: 3 + 4', () => {
+        const posStartNum1 = new PositionTracker(0, 1, 1);
+        const posStartPlus = new PositionTracker(2, 1, 3);
+        const posStartNum2 = new PositionTracker(4, 1, 5);
+        const posStartEof = new PositionTracker(5, 1, 6);
+
+        const tokenList: Array<Token> = [
+          createToken(NUMBER, posStartNum1, 3), createToken(PLUS, posStartPlus),
+          createToken(NUMBER, posStartNum2, 4), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 3) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 4) };
+        const binaryNode: ASTNode = {
+          token: createToken(PLUS, posStartPlus),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(binaryNode);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for binary operation expression: 10 - 9', () => {
+        const posStartNum1 = new PositionTracker(0, 1, 1);
+        const posStartMinus = new PositionTracker(3, 1, 4);
+        const posStartNum2 = new PositionTracker(5, 1, 6);
+        const posStartEof = new PositionTracker(6, 1, 7);
+
+        const tokenList: Array<Token> = [
+          createToken(NUMBER, posStartNum1, 10), createToken(MINUS, posStartMinus),
+          createToken(NUMBER, posStartNum2, 9), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 10) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 9) };
+        const binaryNode: ASTNode = {
+          token: createToken(MINUS, posStartMinus),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(binaryNode);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for binary operation expression: 8 * 4', () => {
+        const posStartNum1 = new PositionTracker(0, 1, 1);
+        const posStartMultiply = new PositionTracker(2, 1, 3);
+        const posStartNum2 = new PositionTracker(4, 1, 5);
+        const posStartEof = new PositionTracker(5, 1, 6);
+
+        const tokenList: Array<Token> = [
+          createToken(NUMBER, posStartNum1, 8), createToken(MULTIPLY, posStartMultiply),
+          createToken(NUMBER, posStartNum2, 4), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 8) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 4) };
+        const binaryNode: ASTNode = {
+          token: createToken(MULTIPLY, posStartMultiply),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(binaryNode);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for binary operation expression: 8 / 4', () => {
+        const posStartNum1 = new PositionTracker(0, 1, 1);
+        const posStartDivide = new PositionTracker(2, 1, 3);
+        const posStartNum2 = new PositionTracker(4, 1, 5);
+        const posStartEof = new PositionTracker(5, 1, 6);
+
+        const tokenList: Array<Token> = [
+          createToken(NUMBER, posStartNum1, 8), createToken(DIVIDE, posStartDivide),
+          createToken(NUMBER, posStartNum2, 4), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 8) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 4) };
+        const binaryNode: ASTNode = {
+          token: createToken(DIVIDE, posStartDivide),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(binaryNode);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for expression: ((1 + 2) * (4 - 1))', () => {
+        const posStartOuterLeftBrack = new PositionTracker(0, 1, 1);
+        const posStartInnerLeftBrack1 = new PositionTracker(1, 1, 2);
+        const posStartNum1 = new PositionTracker(2, 1, 3);
+        const posStartPlus = new PositionTracker(4, 1, 5);
+        const posStartNum2 = new PositionTracker(6, 1, 7);
+        const posStartInnerRightBrack1 = new PositionTracker(7, 1, 8);
+        const posStartMultiply = new PositionTracker(9, 1, 10);
+        const posStartInnerLeftBrack2 = new PositionTracker(11, 1, 12);
+        const posStartNum3 = new PositionTracker(12, 1, 13);
+        const posStartMinus = new PositionTracker(14, 1, 15);
+        const posStartNum4 = new PositionTracker(16, 1, 17);
+        const posStartInnerRightBrack2 = new PositionTracker(17, 1, 18);
+        const posStartOuterRightBrack = new PositionTracker(18, 1, 19);
+        const posStartEof = new PositionTracker(19, 1, 20);
+
+        const tokenList: Array<Token> = [
+          createToken(L_BRACKET, posStartOuterLeftBrack),
+          createToken(L_BRACKET, posStartInnerLeftBrack1),
+          createToken(NUMBER, posStartNum1, 1), createToken(PLUS, posStartPlus),
+          createToken(NUMBER, posStartNum2, 2), createToken(R_BRACKET, posStartInnerRightBrack1),
+          createToken(MULTIPLY, posStartMultiply), createToken(L_BRACKET, posStartInnerLeftBrack2),
+          createToken(NUMBER, posStartNum3, 4), createToken(MINUS, posStartMinus),
+          createToken(NUMBER, posStartNum4, 1), createToken(R_BRACKET, posStartInnerRightBrack2),
+          createToken(R_BRACKET, posStartOuterRightBrack), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 2) };
+        const leftBinaryExp: ASTNode = {
+          token: createToken(PLUS, posStartPlus),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = { token: createToken(NUMBER, posStartNum3, 4) };
+        const numberNode4: ASTNode = { token: createToken(NUMBER, posStartNum4, 1) };
+        const rightBinaryExp: ASTNode = {
+          token: createToken(MINUS, posStartMinus),
+          leftChild: numberNode3,
+          rightChild: numberNode4
+        };
+
+        const ast: ASTNode = {
+          token: createToken(MULTIPLY, posStartMultiply),
+          leftChild: leftBinaryExp,
+          rightChild: rightBinaryExp
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for expression: (1 + 2) / 3', () => {
+        const posStartLeftBrack = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(1, 1, 2);
+        const posStartPlus = new PositionTracker(3, 1, 4);
+        const posStartNum2 = new PositionTracker(5, 1, 6);
+        const posStartRightBrack = new PositionTracker(6, 1, 7);
+        const posStartDivide = new PositionTracker(8, 1, 9);
+        const posStartNum3 = new PositionTracker(10, 1, 11);
+        const posStartEof = new PositionTracker(11, 1, 12);
+
+        const tokenList: Array<Token> = [
+          createToken(L_BRACKET, posStartLeftBrack), createToken(NUMBER, posStartNum1, 1),
+          createToken(PLUS, posStartPlus), createToken(NUMBER, posStartNum2, 2),
+          createToken(R_BRACKET, posStartRightBrack), createToken(DIVIDE, posStartDivide),
+          createToken(NUMBER, posStartNum3, 3), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 2) };
+        const binaryExp: ASTNode = {
+          token: createToken(PLUS, posStartPlus),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = { token: createToken(NUMBER, posStartNum3, 3) };
+
+        const ast: ASTNode = {
+          token: createToken(DIVIDE, posStartDivide),
+          leftChild: binaryExp,
+          rightChild: numberNode3
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for expression: -((1 + 2) * (4 - 1))', () => {
+        const posStartMinusUnary = new PositionTracker(0, 1, 1);
+        const posStartOuterLeftBrack = new PositionTracker(1, 1, 2);
+        const posStartInnerLeftBrack1 = new PositionTracker(2, 1, 3);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartPlus = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(7, 1, 8);
+        const posStartInnerRightBrack1 = new PositionTracker(8, 1, 9);
+        const posStartMultiply = new PositionTracker(10, 1, 11);
+        const posStartInnerLeftBrack2 = new PositionTracker(12, 1, 13);
+        const posStartNum3 = new PositionTracker(13, 1, 14);
+        const posStartMinus = new PositionTracker(15, 1, 16);
+        const posStartNum4 = new PositionTracker(17, 1, 18);
+        const posStartInnerRightBrack2 = new PositionTracker(18, 1, 19);
+        const posStartOuterRightBrack = new PositionTracker(19, 1, 20);
+        const posStartEof = new PositionTracker(20, 1, 21);
+
+        const tokenList: Array<Token> = [
+          createToken(MINUS, posStartMinusUnary), createToken(L_BRACKET, posStartOuterLeftBrack),
+          createToken(L_BRACKET, posStartInnerLeftBrack1),
+          createToken(NUMBER, posStartNum1, 1), createToken(PLUS, posStartPlus),
+          createToken(NUMBER, posStartNum2, 2), createToken(R_BRACKET, posStartInnerRightBrack1),
+          createToken(MULTIPLY, posStartMultiply), createToken(L_BRACKET, posStartInnerLeftBrack2),
+          createToken(NUMBER, posStartNum3, 4), createToken(MINUS, posStartMinus),
+          createToken(NUMBER, posStartNum4, 1), createToken(R_BRACKET, posStartInnerRightBrack2),
+          createToken(R_BRACKET, posStartOuterRightBrack), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 2) };
+        const leftBinaryExp: ASTNode = {
+          token: createToken(PLUS, posStartPlus),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = { token: createToken(NUMBER, posStartNum3, 4) };
+        const numberNode4: ASTNode = { token: createToken(NUMBER, posStartNum4, 1) };
+        const rightBinaryExp: ASTNode = {
+          token: createToken(MINUS, posStartMinus),
+          leftChild: numberNode3,
+          rightChild: numberNode4
+        };
+
+        const outerBinaryExp: ASTNode = {
+          token: createToken(MULTIPLY, posStartMultiply),
+          leftChild: leftBinaryExp,
+          rightChild: rightBinaryExp
+        };
+
+        const unaryExp: ASTNode = {
+          token: createToken(MINUS, posStartMinusUnary),
+          node: outerBinaryExp
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(unaryExp);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return parse result with correct missing operation error for expression: 10 200', () => {
+        const posStartNum1 = new PositionTracker(0, 1, 1);
+        const posEndNum1 = new PositionTracker(1, 1, 2);
+        const posStartNum2 = new PositionTracker(3, 1, 4);
+        const posStartEof = new PositionTracker(4, 1, 5);
+
+        const tokenList: Array<Token> = [
+          createToken(NUMBER, posStartNum1, 10), createToken(NUMBER, posStartNum2, 200),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 10) };
+        const error = new InvalidSyntaxError(`Expected '+', '-', '*' or '/'`, posStartNum1,
+                                                                               posEndNum1);
+
+        let expected = new ParseResult();
+        expected.success(numberNode1);
+        expected.failure(error);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return parse result with correct missing operation error for expression: (1 + 2) 4', () => {
+        const posStartLeftBrack = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(1, 1, 2);
+        const posStartPlus = new PositionTracker(3, 1, 4);
+        const posEndPlus = new PositionTracker(4, 1, 5);
+        const posStartNum2 = new PositionTracker(5, 1, 6);
+        const posStartRightBrack = new PositionTracker(6, 1, 7);
+        const posStartNum3 = new PositionTracker(8, 1, 9);
+        const posStartEof = new PositionTracker(9, 1, 10);
+
+        const tokenList: Array<Token> = [
+          createToken(L_BRACKET, posStartLeftBrack), createToken(NUMBER, posStartNum1, 1),
+          createToken(PLUS, posStartPlus), createToken(NUMBER, posStartNum2, 2),
+          createToken(R_BRACKET, posStartRightBrack), createToken(NUMBER, posStartNum3, 4),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 2) };
+        const binaryExp: ASTNode = {
+          token: createToken(PLUS, posStartPlus),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const error = new InvalidSyntaxError(`Expected '+', '-', '*' or '/'`, posStartPlus,
+                                                                               posEndPlus);
+
+        let expected = new ParseResult();
+        expected.success(binaryExp);
+        expected.failure(error);
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return parse result with correct 'missing ')'' error for expression: ((1 + 2) - 1`, () => {
+        const posStartLeftBrack1 = new PositionTracker(0, 1, 1);
+        const posStartLeftBrack2 = new PositionTracker(1, 1, 2);
+        const posStartNum1 = new PositionTracker(2, 1, 3);
+        const posStartPlus = new PositionTracker(4, 1, 5);
+        const posStartNum2 = new PositionTracker(6, 1, 7);
+        const posStartRightBrack = new PositionTracker(7, 1, 8);
+        const posStartMinus = new PositionTracker(9, 1, 10);
+        const posStartNum3 = new PositionTracker(11, 1, 12);
+        const posStartEof = new PositionTracker(12, 1, 13);
+        const posEndEof = new PositionTracker(13, 1, 14);
+
+        const tokenList: Array<Token> = [
+          createToken(L_BRACKET, posStartLeftBrack1), createToken(L_BRACKET, posStartLeftBrack2),
+          createToken(NUMBER, posStartNum1, 1), createToken(PLUS, posStartPlus),
+          createToken(NUMBER, posStartNum2, 2), createToken(R_BRACKET, posStartRightBrack),
+          createToken(MINUS, posStartMinus), createToken(NUMBER, posStartNum3, 1),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`missing ')'`, posStartEof, posEndEof);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        expect(parseResult).toEqual(expected);
+      });
+    });
+  });
+});
+
+// Utility functions.
+function createToken(type: string, posStart: PositionTracker, value?: any): Token {
+
+  let token: Token;
+
+  const posStartNew = posStart.copy();
+  let posEnd = posStart.copy();
+  posEnd.advance();
+
+  if (value === undefined) {
+    token = {
+      type: type,
+      positionStart: posStartNew,
+      positionEnd: posEnd
+    };
+  }
+  else {
+    token = {
+      type: type,
+      positionStart: posStartNew,
+      positionEnd: posEnd,
+      value: value
+    };
+  }
+
+  return token;
+}

--- a/src/app/logic/parser.ts
+++ b/src/app/logic/parser.ts
@@ -88,12 +88,14 @@ export class Parser {
         return parseResult.success(expr);
       }
       else {
-        const syntaxError = new InvalidSyntaxError(`missing ')'`);
+        const syntaxError = new InvalidSyntaxError(`missing ')'`, this.currentToken.positionStart,
+                                                                  this.currentToken.positionEnd);
         return parseResult.failure(syntaxError);
       }
     }
 
-    const syntaxError = new InvalidSyntaxError('Expected a number');
+    const syntaxError = new InvalidSyntaxError('Expected a number', this.currentToken.positionStart,
+                                                                    this.currentToken.positionEnd);
     return parseResult.failure(syntaxError);
   }
 
@@ -111,7 +113,10 @@ export class Parser {
     let parseResult: ParseResult = this.expr();
 
     if (parseResult.getError() === null && this.currentToken.type !== EOF) {
-      const syntaxError = new InvalidSyntaxError(`Expected '+', '-', '*' or '/'`);
+      const node: ASTNode = parseResult.getNode();
+      const syntaxError = new InvalidSyntaxError(`Expected '+', '-', '*' or '/'`,
+                                                  node.token.positionStart,
+                                                  node.token.positionEnd);
       return parseResult.failure(syntaxError);
     }
 

--- a/src/app/logic/parser.ts
+++ b/src/app/logic/parser.ts
@@ -1,0 +1,4 @@
+export class Parser {
+
+  constructor() {}
+}

--- a/src/app/logic/parser.ts
+++ b/src/app/logic/parser.ts
@@ -1,4 +1,78 @@
+import { BinaryOpNode } from './../models/binary-op-node';
+import { NumberNode } from './../models/number-node';
+import { ASTNode } from '../models/ast-node';
+import { Token } from '../models/token';
+import { NUMBER, MULTIPLY, DIVIDE, PLUS, MINUS } from './token-type.constants';
+
+/**
+ * This Parser implements a recursive descent parser.
+ */
 export class Parser {
 
-  constructor() {}
+  private tokenIdx: number;
+  private currentToken: Token;
+
+  constructor(private tokens: Array<Token>) {
+    this.tokenIdx = -1;
+    this.advance();
+  }
+
+  private advance(): void {
+
+    this.tokenIdx++;
+
+    if (this.tokenIdx < this.tokens.length) {
+      this.currentToken = this.tokens[this.tokenIdx];
+    }
+  }
+
+  private binaryOperators(grammerFunc: string, ops: Set<string>): BinaryOpNode | NumberNode {
+    let leftNode: BinaryOpNode | NumberNode;
+    let rightNode: BinaryOpNode | NumberNode;
+
+    if (grammerFunc === 'term') { leftNode = this.term(); }
+    else { leftNode = this.factor(); }
+
+    while (ops.has(this.currentToken.type)) {
+      let opToken = this.currentToken;
+      this.advance();
+
+      if (grammerFunc === 'term') { rightNode = this.term(); }
+      else { rightNode = this.factor(); }
+
+      leftNode = {
+        token: opToken,
+        leftChild: leftNode,
+        rightChild: rightNode
+      };
+    }
+
+    return leftNode;
+  }
+
+  private factor(): NumberNode {
+
+    let tok = this.currentToken;
+
+    if (tok.type === NUMBER) {
+      this.advance();
+      let numberNode: NumberNode = {token: tok};
+      return numberNode;
+    }
+  }
+
+  private term(): BinaryOpNode | NumberNode {
+    let operators: Set<string> = new Set([MULTIPLY, DIVIDE]);
+    return this.binaryOperators('factor', operators);
+  }
+
+  private expr(): BinaryOpNode | NumberNode {
+    let operators: Set<string> = new Set([PLUS, MINUS]);
+    return this.binaryOperators('term', operators);
+  }
+
+  public parse(): ASTNode {
+    let astNode: ASTNode = this.expr();
+    return astNode;
+  }
 }

--- a/src/app/logic/parser.ts
+++ b/src/app/logic/parser.ts
@@ -1,9 +1,10 @@
+import { ParseResult } from './parse-result';
 import { InvalidSyntaxError } from './invalid-syntax-error';
 import { BinaryOpNode } from './../models/binary-op-node';
 import { NumberNode } from './../models/number-node';
 import { ASTNode } from '../models/ast-node';
 import { Token } from '../models/token';
-import { NUMBER, MULTIPLY, DIVIDE, PLUS, MINUS, L_BRACKET, R_BRACKET } from './token-type.constants';
+import { NUMBER, MULTIPLY, DIVIDE, PLUS, MINUS, L_BRACKET, R_BRACKET, EOF } from './token-type.constants';
 import { UnaryOpNode } from '../models/unary-op-node';
 
 /**
@@ -19,28 +20,33 @@ export class Parser {
     this.advance();
   }
 
-  private advance(): void {
+  private advance(): Token {
 
     this.tokenIdx++;
 
     if (this.tokenIdx < this.tokens.length) {
       this.currentToken = this.tokens[this.tokenIdx];
     }
+
+    return this.currentToken;
   }
 
-  private binaryOperators(grammerFunc: string, ops: Set<string>): ASTNode | InvalidSyntaxError {
-    let leftNode: ASTNode | InvalidSyntaxError;
-    let rightNode: ASTNode | InvalidSyntaxError;
+  private binaryOperators(grammerFunc: string, ops: Set<string>): ParseResult {
+    let parseResult = new ParseResult();
+    let leftNode: ASTNode;
+    let rightNode: ASTNode;
 
-    if (grammerFunc === 'term') { leftNode = this.term(); }
-    else { leftNode = this.factor(); }
+    if (grammerFunc === 'term') { leftNode = parseResult.register(this.term()); }
+    else { leftNode = parseResult.register(this.factor()); }
+
+    if (parseResult.getError() !== null) { return parseResult; }
 
     while (ops.has(this.currentToken.type)) {
       let opToken = this.currentToken;
-      this.advance();
+      parseResult.register(this.advance());
 
-      if (grammerFunc === 'term') { rightNode = this.term(); }
-      else { rightNode = this.factor(); }
+      if (grammerFunc === 'term') { rightNode = parseResult.register(this.term()); }
+      else { rightNode = parseResult.register(this.factor()); }
 
       leftNode = {
         token: opToken,
@@ -49,54 +55,66 @@ export class Parser {
       };
     }
 
-    return leftNode;
+    return parseResult.success(leftNode);
   }
 
-  private factor(): ASTNode | InvalidSyntaxError {
+  private factor(): ParseResult {
 
+    let parseResult = new ParseResult();
     let tok = this.currentToken;
 
     if (tok.type === PLUS || tok.type === MINUS) {
-      this.advance();
-      let factor = this.factor();
+      parseResult.register(this.advance());
+      let factor = parseResult.register(this.factor());
 
-      if (!(factor instanceof InvalidSyntaxError)) {
-        const unaryOpNode: UnaryOpNode = {token: tok, node: factor};
-        return unaryOpNode;
-      }
+      if (parseResult.getError() !== null) { return parseResult; }
+
+      const unaryOpNode: UnaryOpNode = {token: tok, node: factor};
+      return parseResult.success(unaryOpNode);
     }
     else if (tok.type === NUMBER) {
-      this.advance();
+      parseResult.register(this.advance());
       let numberNode: NumberNode = {token: tok};
-      return numberNode;
+      return parseResult.success(numberNode);
     }
     else if (tok.type === L_BRACKET) {
-      this.advance();
-      let expr = this.expr();
+      parseResult.register(this.advance());
+      let expr = parseResult.register(this.expr());
+
+      if (parseResult.getError() !== null) { return parseResult; }
 
       if (this.currentToken.type === R_BRACKET) {
-        this.advance();
-        return expr;
+        parseResult.register(this.advance());
+        return parseResult.success(expr);
       }
       else {
         const syntaxError = new InvalidSyntaxError(`missing ')'`);
-        return syntaxError;
+        return parseResult.failure(syntaxError);
       }
     }
+
+    const syntaxError = new InvalidSyntaxError('Expected a number');
+    return parseResult.failure(syntaxError);
   }
 
-  private term(): ASTNode | InvalidSyntaxError {
+  private term(): ParseResult {
     let operators: Set<string> = new Set([MULTIPLY, DIVIDE]);
     return this.binaryOperators('factor', operators);
   }
 
-  private expr(): ASTNode | InvalidSyntaxError {
+  private expr(): ParseResult {
     let operators: Set<string> = new Set([PLUS, MINUS]);
     return this.binaryOperators('term', operators);
   }
 
-  public parse(): ASTNode | InvalidSyntaxError {
-    let astNode: ASTNode | InvalidSyntaxError = this.expr();
-    return astNode;
+  public parse(): ParseResult {
+    let parseResult: ParseResult = this.expr();
+
+    if (parseResult.getError() === null && this.currentToken.type !== EOF) {
+      const syntaxError = new InvalidSyntaxError(`Expected '+', '-', '*' or '/'`);
+      return parseResult.failure(syntaxError);
+    }
+
+    return parseResult;
   }
 }

--- a/src/app/logic/position-tracker.spec.ts
+++ b/src/app/logic/position-tracker.spec.ts
@@ -1,0 +1,62 @@
+import { PositionTracker } from './position-tracker';
+
+describe('PositionTracker tests', () => {
+  it('should initialise with the correct values for index, line and column', () => {
+    const positionTracker = new PositionTracker(0, 1, 1);
+    const [index, line, column] = positionTracker.getAllTrackerValues();
+
+    expect(index).toEqual(0);
+    expect(line).toEqual(1);
+    expect(column).toEqual(1);
+  });
+
+  describe('advance tests', () => {
+    it('should increment index and column same amount as advance is called', () => {
+      const numberOfAdvances = 3;
+      const positionTracker = new PositionTracker(0, 1, 1);
+
+      for(let i = 0; i < numberOfAdvances; i++){ positionTracker.advance(); }
+
+      const [index, line, column] = positionTracker.getAllTrackerValues();
+
+      expect(index).toEqual(3);
+      expect(line).toEqual(1);
+      expect(column).toEqual(4);
+    });
+
+    it('should reset column to 0 and increment index and line when newline character passed', () => {
+      const numberOfAdvances = 3;
+      const positionTracker = new PositionTracker(0, 1, 1);
+
+      for(let i = 0; i < numberOfAdvances; i++){ positionTracker.advance(); }
+
+      positionTracker.advance('\n');
+
+      const [index, line, column] = positionTracker.getAllTrackerValues();
+
+      expect(index).toEqual(4);
+      expect(line).toEqual(2);
+      expect(column).toEqual(1);
+    });
+  });
+
+  describe('copy tests', () => {
+    it('should create independent copy of PositionTracker instance which changes attributes independently', () => {
+      const numberOfAdvances = 3;
+      const positionTracker1 = new PositionTracker(0, 1, 1);
+      const positionTracker2 = positionTracker1.copy();
+
+      for(let i = 0; i < numberOfAdvances; i++){ positionTracker2.advance(); }
+
+      const [index1, line1, column1] = positionTracker1.getAllTrackerValues();
+      const [index2, line2, column2] = positionTracker2.getAllTrackerValues();
+
+      expect(index1).toEqual(0);
+      expect(line1).toEqual(1);
+      expect(column1).toEqual(1);
+      expect(index2).toEqual(3);
+      expect(line2).toEqual(1);
+      expect(column2).toEqual(4);
+    });
+  })
+});

--- a/src/app/logic/position-tracker.ts
+++ b/src/app/logic/position-tracker.ts
@@ -1,0 +1,34 @@
+export class PositionTracker {
+
+  constructor(private index: number, private line: number, private column: number) {}
+
+  public advance(currentCharacter?: string): void {
+    this.index++;
+    this.column++;
+
+    if (currentCharacter === '\n') {
+      this.line++;
+      this.column = 1;
+    }
+  }
+
+  public copy(): PositionTracker {
+    return new PositionTracker(this.index, this.line, this.column);
+  }
+
+  public getAllTrackerValues(): [number, number, number] {
+    return [this.index, this.line, this.column];
+  }
+
+  public getIndex(): number {
+    return this.index;
+  }
+
+  public getLine(): number {
+    return this.line;
+  }
+
+  public getColumn(): number {
+    return this.column;
+  }
+}

--- a/src/app/logic/token-type.constants.ts
+++ b/src/app/logic/token-type.constants.ts
@@ -15,3 +15,4 @@ export const G_THAN = 'G_THAN';
 export const L_THAN = 'L_THAN';
 export const G_THAN_EQ = 'G_THAN_EQ';
 export const L_THAN_EQ = 'L_THAN_EQ';
+export const EOF = 'EOF';

--- a/src/app/models/ast-node.ts
+++ b/src/app/models/ast-node.ts
@@ -1,0 +1,7 @@
+import { Token } from './token';
+
+export interface ASTNode {
+  token: Token,
+  leftChild?: ASTNode,
+  rightChild?: ASTNode
+}

--- a/src/app/models/ast-node.ts
+++ b/src/app/models/ast-node.ts
@@ -1,7 +1,10 @@
+import { InvalidSyntaxError } from './../logic/invalid-syntax-error';
 import { Token } from './token';
+import { NumberNode } from './number-node';
 
 export interface ASTNode {
   token: Token,
-  leftChild?: ASTNode,
-  rightChild?: ASTNode
+  leftChild?: ASTNode | InvalidSyntaxError,
+  rightChild?: ASTNode | InvalidSyntaxError,
+  node?: ASTNode | InvalidSyntaxError // Some nodes have single nodes such as NumberNode.
 }

--- a/src/app/models/binary-op-node.ts
+++ b/src/app/models/binary-op-node.ts
@@ -1,0 +1,8 @@
+import { ASTNode } from './ast-node';
+import { Token } from './token';
+
+export interface BinaryOpNode extends ASTNode {
+  token: Token,
+  leftChild: ASTNode,
+  rightChild: ASTNode
+}

--- a/src/app/models/number-node.ts
+++ b/src/app/models/number-node.ts
@@ -1,0 +1,6 @@
+import { ASTNode } from './ast-node';
+import { Token } from './token';
+
+export interface NumberNode extends ASTNode {
+  token: Token
+}

--- a/src/app/models/token.ts
+++ b/src/app/models/token.ts
@@ -1,4 +1,4 @@
 export interface Token {
   type: string,
   value?: any
-};
+}

--- a/src/app/models/token.ts
+++ b/src/app/models/token.ts
@@ -1,4 +1,8 @@
+import { PositionTracker } from './../logic/position-tracker';
+
 export interface Token {
   type: string,
+  positionStart: PositionTracker,
+  positionEnd: PositionTracker,
   value?: any
 }

--- a/src/app/models/unary-op-node.ts
+++ b/src/app/models/unary-op-node.ts
@@ -2,8 +2,7 @@ import { InvalidSyntaxError } from './../logic/invalid-syntax-error';
 import { ASTNode } from './ast-node';
 import { Token } from './token';
 
-export interface BinaryOpNode extends ASTNode {
+export interface UnaryOpNode extends ASTNode {
   token: Token,
-  leftChild: ASTNode | InvalidSyntaxError,
-  rightChild: ASTNode | InvalidSyntaxError
+  node: ASTNode | InvalidSyntaxError
 }

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -5,6 +5,7 @@ import { Parser } from './../logic/parser';
 import { Injectable } from '@angular/core';
 import { Token } from '../models/token';
 import { Lexer } from '../logic/lexer';
+import { ParseResult } from '../logic/parse-result';
 
 @Injectable({
   providedIn: 'root'
@@ -29,7 +30,7 @@ export class InterpreterService {
     }
     else {
       this.parser = new Parser(lexerOutput);
-      let ast: ASTNode | InvalidSyntaxError = this.parser.parse();
+      let parseResult: ParseResult = this.parser.parse();
       // TODO: Create visitor functionality to traverse AST and execute program.
     }
 

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -1,3 +1,4 @@
+import { InvalidSyntaxError } from './../logic/invalid-syntax-error';
 import { ASTNode } from './../models/ast-node';
 import { Error } from './../logic/error';
 import { Parser } from './../logic/parser';
@@ -28,7 +29,7 @@ export class InterpreterService {
     }
     else {
       this.parser = new Parser(lexerOutput);
-      let ast: ASTNode = this.parser.parse();
+      let ast: ASTNode | InvalidSyntaxError = this.parser.parse();
       // TODO: Create visitor functionality to traverse AST and execute program.
     }
 

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -1,3 +1,4 @@
+import { Parser } from './../logic/parser';
 import { Injectable } from '@angular/core';
 import { Lexer } from '@angular/compiler';
 
@@ -7,8 +8,10 @@ import { Lexer } from '@angular/compiler';
 export class InterpreterService {
 
   private lexer: Lexer;
+  private parser: Parser;
 
   constructor() {
     this.lexer = new Lexer();
+    this.parser = new Parser();
   }
 }

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -1,6 +1,9 @@
+import { ASTNode } from './../models/ast-node';
+import { Error } from './../logic/error';
 import { Parser } from './../logic/parser';
 import { Injectable } from '@angular/core';
-import { Lexer } from '@angular/compiler';
+import { Token } from '../models/token';
+import { Lexer } from '../logic/lexer';
 
 @Injectable({
   providedIn: 'root'
@@ -12,6 +15,23 @@ export class InterpreterService {
 
   constructor() {
     this.lexer = new Lexer();
-    this.parser = new Parser();
+  }
+
+  public evaluate(source: string): string {
+
+    let output = '';
+
+    let lexerOutput: Array<Token> | Error = this.lexer.lex(source);
+
+    if (lexerOutput instanceof Error) {
+      output = lexerOutput.getErrorMessage();
+    }
+    else {
+      this.parser = new Parser(lexerOutput);
+      let ast: ASTNode = this.parser.parse();
+      // TODO: Create visitor functionality to traverse AST and execute program.
+    }
+
+    return output;
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -83,11 +83,11 @@
       true,
       "single"
     ],
-    "semicolon": {
-      "options": [
-        "always"
-      ]
-    },
+    // "semicolon": {
+    //   "options": [
+    //     "always"
+    //   ]
+    // },
     "space-before-function-paren": {
       "options": {
         "anonymous": "never",


### PR DESCRIPTION
Created a basic version of the parser (based on a recursive-descent parser) which at the moment can parse through arithmetic expressions including the +, -, * and / operations and supports bracketed precedence as well as operation precedence. The parser generates an appropriate Abstract Syntax Tree made up of `ParseResult`s which group information about the nodes in the tree and the errors (if they exist). Also added a syntax error detector in the parser as well as a new `PositionTracker` class to track the index, line and column number of the tokens for better feedback in error messages. Unit tests were written for all these new features related to the parser covering the different supported expressions and erroneous expressions.