### PR TITLE
feat(parser-variables): added parser support for variable assignment/access

### DIFF
--- a/src/app/logic/lexer.spec.ts
+++ b/src/app/logic/lexer.spec.ts
@@ -204,6 +204,83 @@ describe('Lexer tests', () => {
 
         expect(tokens).toEqual(expected);
       });
+
+      it('should return list with correct token if string is: variable_name', () => {
+
+        const sourceCode: string = 'variable_name';
+        const lexer: Lexer = new Lexer();
+
+        const tokens: Array<Token> | Error = lexer.lex(sourceCode);
+
+        const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(13, 1, 14));
+        const expectedToken: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'variable_name');
+        const expected: Array<Token> = [expectedToken, eofToken];
+
+        expect(tokens).toEqual(expected);
+      });
+
+      it('should return list with correct token if string is: _variable', () => {
+
+        const sourceCode: string = '_variable';
+        const lexer: Lexer = new Lexer();
+
+        const tokens: Array<Token> | Error = lexer.lex(sourceCode);
+
+        const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(9, 1, 10));
+        const expectedToken: Token = createToken(TokenTypes.IDENTIFIER, posTracker, '_variable');
+        const expected: Array<Token> = [expectedToken, eofToken];
+
+        expect(tokens).toEqual(expected);
+      });
+
+      it('should return list with correct token if string is: variable1', () => {
+
+        const sourceCode: string = 'variable1';
+        const lexer: Lexer = new Lexer();
+
+        const tokens: Array<Token> | Error = lexer.lex(sourceCode);
+
+        const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(9, 1, 10));
+        const expectedToken: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'variable1');
+        const expected: Array<Token> = [expectedToken, eofToken];
+
+        expect(tokens).toEqual(expected);
+      });
+
+      it('should return list with correct token if string is: variable123', () => {
+
+        const sourceCode: string = 'variable123';
+        const lexer: Lexer = new Lexer();
+
+        const tokens: Array<Token> | Error = lexer.lex(sourceCode);
+
+        const posTracker = new PositionTracker(0, 1, 1);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(11, 1, 12));
+        const expectedToken: Token = createToken(TokenTypes.IDENTIFIER, posTracker, 'variable123');
+        const expected: Array<Token> = [expectedToken, eofToken];
+
+        expect(tokens).toEqual(expected);
+      });
+
+      it('should return list with correct token if string is: 1variable', () => {
+
+        const sourceCode: string = '1variable';
+        const lexer: Lexer = new Lexer();
+
+        const tokens: Array<Token> | Error = lexer.lex(sourceCode);
+
+        const posTrackerNum = new PositionTracker(0, 1, 1);
+        const posTrackerVar = new PositionTracker(1, 1, 2);
+        const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(9, 1, 10));
+        const expectedNumToken: Token = createToken(TokenTypes.NUMBER, posTrackerNum, 1);
+        const expectedVarToken: Token = createToken(TokenTypes.IDENTIFIER, posTrackerVar, 'variable');
+        const expected: Array<Token> = [expectedNumToken, expectedVarToken, eofToken];
+
+        expect(tokens).toEqual(expected);
+      });
     });
 
     describe('Comparator and equal symbol tokens tests', () => {

--- a/src/app/logic/lexer.ts
+++ b/src/app/logic/lexer.ts
@@ -56,7 +56,7 @@ export class Lexer {
           tokens.push(token);
         }
       }
-      else if (this.isAlphabeticalCharacter(char)) {
+      else if (this.isAlphabeticalCharacter(char) || char === '_') {
         const result: string = this.scanString(source);
         const token: Token = this.createToken(TokenTypes.IDENTIFIER, startOfTokenPosTracker, result);
         tokens.push(token);
@@ -260,13 +260,16 @@ export class Lexer {
 
     let char: string = source.charAt(this.positionTracker.getIndex());
     let value: string = '';
+    let considerNumbers = false;
 
-    while (this.isAlphabeticalCharacter(char) &&
+    while ((this.isAlphabeticalCharacter(char) || char === '_' ||
+           (considerNumbers && this.isDigit(char))) &&
            this.positionTracker.getIndex() < source.length) {
       value = value + char
 
       this.positionTracker.advance();
       char = source.charAt(this.positionTracker.getIndex());
+      considerNumbers = true;
     }
 
     return value;

--- a/src/app/logic/lexer.ts
+++ b/src/app/logic/lexer.ts
@@ -255,6 +255,7 @@ export class Lexer {
     return char.toUpperCase() != char.toLowerCase();
   }
 
+  // TODO: Change so that underscore variables can be used or variable names with numbers.
   private scanString(source: string): string {
 
     let char: string = source.charAt(this.positionTracker.getIndex());

--- a/src/app/logic/parse-result.spec.ts
+++ b/src/app/logic/parse-result.spec.ts
@@ -6,11 +6,12 @@ import { Token } from '../models/token';
 import { EQUALS } from './token-type.constants';
 
 describe('ParseResult tests', () => {
-  it('should initialise node and error attributes as null', () => {
+  it('should initialise node and error attributes as null and advanceCount to 0', () => {
     const parseResult = new ParseResult();
 
     expect(parseResult.getError()).toEqual(null);
     expect(parseResult.getNode()).toEqual(null);
+    expect(parseResult.getAdvanceCount()).toEqual(0);
   });
 
   describe('success tests', () => {
@@ -22,6 +23,7 @@ describe('ParseResult tests', () => {
 
       expect(parseResult.getNode()).toEqual(astNode);
       expect(parseResult.getError()).toEqual(null);
+      expect(parseResult.getAdvanceCount()).toEqual(0);
     });
   });
 
@@ -36,21 +38,11 @@ describe('ParseResult tests', () => {
 
       expect(parseResult.getError()).toEqual(syntaxError);
       expect(parseResult.getNode()).toEqual(null);
+      expect(parseResult.getAdvanceCount()).toEqual(0);
     });
   });
 
   describe('register tests', () => {
-    it('should return passed node arg and keep node and error attributes null', () => {
-      const astNode: ASTNode = createASTNode(EQUALS);
-      const parseResult = new ParseResult();
-
-      const returnedNode: ASTNode = parseResult.register(astNode);
-
-      expect(returnedNode).toEqual(astNode);
-      expect(parseResult.getNode()).toEqual(null);
-      expect(parseResult.getError()).toEqual(null);
-    });
-
     it('should return node in passed in parse result and assign error if error exists in passed parse result', () => {
       const posStart = new PositionTracker(4, 1, 5);
       const posEnd = new PositionTracker(5, 1, 6);
@@ -64,6 +56,7 @@ describe('ParseResult tests', () => {
       expect(returnedNode).toEqual(errorParseResult.getNode());
       expect(parseResult.getNode()).toEqual(null);
       expect(parseResult.getError()).toEqual(syntaxError);
+      expect(parseResult.getAdvanceCount()).toEqual(0);
     });
 
     it('should return node in passed in parse result and assign node if node exists in passed parse result', () => {
@@ -77,6 +70,31 @@ describe('ParseResult tests', () => {
       expect(returnedNode).toEqual(astNode);
       expect(parseResult.getNode()).toEqual(null);
       expect(parseResult.getError()).toEqual(null);
+      expect(parseResult.getAdvanceCount()).toEqual(0);
+    });
+  });
+
+  describe('registerAdvancement tests', () => {
+    it('should increment advanceCount of parse result when registerAdvancement is called', () => {
+      const parseResult = new ParseResult();
+
+      parseResult.registerAdvancement();
+      expect(parseResult.getAdvanceCount()).toEqual(1);
+
+      parseResult.registerAdvancement();
+      expect(parseResult.getAdvanceCount()).toEqual(2);
+    });
+
+    it('should add advanceCounts of one parse result to another when registering a parse result', () => {
+      const parseResult1 = new ParseResult();
+      const parseResult2 = new ParseResult();
+
+      for (let i = 0; i < 3; i++) { parseResult1.registerAdvancement(); }
+
+      parseResult2.register(parseResult1);
+
+      expect(parseResult1.getAdvanceCount()).toEqual(3);
+      expect(parseResult2.getAdvanceCount()).toEqual(3);
     });
   });
 });

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -3,7 +3,7 @@ import { ASTNode } from '../models/ast-node';
 import { Parser } from './parser';
 import { PositionTracker } from './position-tracker';
 import { Token } from '../models/token';
-import { NUMBER, EOF, MINUS, PLUS, MULTIPLY, DIVIDE, L_BRACKET, R_BRACKET, POWER } from './token-type.constants';
+import { NUMBER, EOF, MINUS, PLUS, MULTIPLY, DIVIDE, L_BRACKET, R_BRACKET, POWER, IDENTIFIER, EQUALS } from './token-type.constants';
 import { ParseResult } from './parse-result';
 
 describe('Parser tests', () => {
@@ -23,6 +23,8 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected = expected.success(numberNode);
 
+        expected.registerAdvancement();
+
         expect(parseResult).toEqual(expected);
       });
 
@@ -39,6 +41,8 @@ describe('Parser tests', () => {
         const numberNode: ASTNode = { token: createToken(NUMBER, posStart, 3.14) };
         let expected = new ParseResult();
         expected = expected.success(numberNode);
+
+        expected.registerAdvancement();
 
         expect(parseResult).toEqual(expected);
       });
@@ -61,6 +65,9 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected = expected.success(unaryNode);
 
+        expected.registerAdvancement();
+        expected.registerAdvancement();
+
         expect(parseResult).toEqual(expected);
       });
 
@@ -81,6 +88,9 @@ describe('Parser tests', () => {
         const unaryNode: ASTNode = { token: createToken(PLUS, posStartPlus), node: numberNode };
         let expected = new ParseResult();
         expected = expected.success(unaryNode);
+
+        expected.registerAdvancement();
+        expected.registerAdvancement();
 
         expect(parseResult).toEqual(expected);
       });
@@ -110,6 +120,8 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected = expected.success(binaryNode);
 
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
+
         expect(parseResult).toEqual(expected);
       });
 
@@ -137,6 +149,8 @@ describe('Parser tests', () => {
 
         let expected = new ParseResult();
         expected = expected.success(binaryNode);
+
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
         expect(parseResult).toEqual(expected);
       });
@@ -166,6 +180,8 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected = expected.success(binaryNode);
 
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
+
         expect(parseResult).toEqual(expected);
       });
 
@@ -194,6 +210,8 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected = expected.success(binaryNode);
 
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
+
         expect(parseResult).toEqual(expected);
       });
 
@@ -221,6 +239,8 @@ describe('Parser tests', () => {
 
         let expected = new ParseResult();
         expected = expected.success(binaryNode);
+
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
         expect(parseResult).toEqual(expected);
       });
@@ -280,6 +300,8 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected = expected.success(ast);
 
+        for (let i = 0; i < 13; i++) { expected.registerAdvancement(); }
+
         expect(parseResult).toEqual(expected);
       });
 
@@ -321,6 +343,8 @@ describe('Parser tests', () => {
 
         let expected = new ParseResult();
         expected = expected.success(ast);
+
+        for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
 
         expect(parseResult).toEqual(expected);
       });
@@ -370,6 +394,8 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected = expected.success(ast);
 
+        for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
+
         expect(parseResult).toEqual(expected);
       });
 
@@ -404,6 +430,8 @@ describe('Parser tests', () => {
 
         let expected = new ParseResult();
         expected = expected.success(ast);
+
+        for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
         expect(parseResult).toEqual(expected);
       });
@@ -455,6 +483,8 @@ describe('Parser tests', () => {
 
         let expected = new ParseResult();
         expected = expected.success(ast);
+
+        for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
 
         expect(parseResult).toEqual(expected);
       });
@@ -520,12 +550,13 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected = expected.success(unaryExp);
 
+        for (let i = 0; i < 14; i++) { expected.registerAdvancement(); }
+
         expect(parseResult).toEqual(expected);
       });
 
       it('should return parse result with correct missing operation error for expression: 10 200', () => {
         const posStartNum1 = new PositionTracker(0, 1, 1);
-        const posEndNum1 = new PositionTracker(1, 1, 2);
         const posStartNum2 = new PositionTracker(3, 1, 4);
         const posStartEof = new PositionTracker(4, 1, 5);
 
@@ -538,12 +569,14 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 10) };
-        const error = new InvalidSyntaxError(`Expected '+', '-', '*' or '/'`, posStartNum1,
-                                                                               posEndNum1);
+        const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/' or '^'`, posStartNum2,
+                                                                               posStartEof);
 
         let expected = new ParseResult();
         expected.success(numberNode1);
         expected.failure(error);
+
+        expected.registerAdvancement();
 
         expect(parseResult).toEqual(expected);
       });
@@ -576,12 +609,14 @@ describe('Parser tests', () => {
           rightChild: numberNode2
         };
 
-        const error = new InvalidSyntaxError(`Expected '+', '-', '*' or '/'`, posStartPlus,
-                                                                               posEndPlus);
+        const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/' or '^'`, posStartNum3,
+                                                                               posStartEof);
 
         let expected = new ParseResult();
         expected.success(binaryExp);
         expected.failure(error);
+
+        for (let i = 0; i < 5; i++) { expected.registerAdvancement(); }
 
         expect(parseResult).toEqual(expected);
       });
@@ -613,6 +648,415 @@ describe('Parser tests', () => {
 
         let expected = new ParseResult();
         expected.failure(error);
+
+        for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+    });
+
+    describe('variable assignment tests', () => {
+      it('should return correct AST for statement: variable = 1', () => {
+        const posStartVariable = new PositionTracker(0, 1, 1);
+        const posStartEquals = new PositionTracker(9, 1, 10);
+        const posStartNum1 = new PositionTracker(11, 1, 12);
+        const posStartEof = new PositionTracker(12, 1, 13);
+
+        const tokenList: Array<Token> = [
+          createToken(IDENTIFIER, posStartVariable, 'variable'),
+          createToken(EQUALS, posStartEquals), createToken(NUMBER, posStartNum1, 1),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const ast: ASTNode = {
+          token: createToken(IDENTIFIER, posStartVariable, 'variable'),
+          node: numberNode1
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: variable = (1 * 3) ^ 2', () => {
+        const posStartVariable = new PositionTracker(0, 1, 1);
+        const posStartEquals = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(11, 1, 12);
+        const posStartNum1 = new PositionTracker(12, 1, 13);
+        const posStartMultiply = new PositionTracker(14, 1, 15);
+        const posStartNum2 = new PositionTracker(16, 1, 17);
+        const posStartRightBrack = new PositionTracker(17, 1, 18);
+        const posStartPower = new PositionTracker(19, 1, 20);
+        const posStartNum3 = new PositionTracker(21, 1, 22);
+        const posStartEof = new PositionTracker(22, 1, 23);
+
+        const tokenList: Array<Token> = [
+          createToken(IDENTIFIER, posStartVariable, 'variable'),
+          createToken(EQUALS, posStartEquals), createToken(L_BRACKET, posStartLeftBrack),
+          createToken(NUMBER, posStartNum1, 1), createToken(MULTIPLY, posStartMultiply),
+          createToken(NUMBER, posStartNum2, 3), createToken(R_BRACKET, posStartRightBrack),
+          createToken(POWER, posStartPower), createToken(NUMBER, posStartNum3, 2),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 3) };
+        const binaryMultExp: ASTNode = {
+          token: createToken(MULTIPLY, posStartMultiply),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = { token: createToken(NUMBER, posStartNum3, 2) };
+        const binaryPowerExp: ASTNode = {
+          token: createToken(POWER, posStartPower),
+          leftChild: binaryMultExp,
+          rightChild: numberNode3
+        };
+
+        const ast: ASTNode = {
+          token: createToken(IDENTIFIER, posStartVariable, 'variable'),
+          node: binaryPowerExp
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: variable = -((1 * 3) ^ 2)', () => {
+        const posStartVariable = new PositionTracker(0, 1, 1);
+        const posStartEquals = new PositionTracker(9, 1, 10);
+        const posStartMinus = new PositionTracker(11, 1, 12);
+        const posStartOuterLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartInnerLeftBrack = new PositionTracker(13, 1, 14);
+        const posStartNum1 = new PositionTracker(14, 1, 15);
+        const posStartMultiply = new PositionTracker(16, 1, 17);
+        const posStartNum2 = new PositionTracker(18, 1, 19);
+        const posStartInnerRightBrack = new PositionTracker(19, 1, 20);
+        const posStartPower = new PositionTracker(21, 1, 22);
+        const posStartNum3 = new PositionTracker(23, 1, 24);
+        const posStartOuterRightBrack = new PositionTracker(24, 1, 25);
+        const posStartEof = new PositionTracker(25, 1, 26);
+
+        const tokenList: Array<Token> = [
+          createToken(IDENTIFIER, posStartVariable, 'variable'),
+          createToken(EQUALS, posStartEquals), createToken(MINUS, posStartMinus),
+          createToken(L_BRACKET, posStartOuterLeftBrack),
+          createToken(L_BRACKET, posStartInnerLeftBrack), createToken(NUMBER, posStartNum1, 1),
+          createToken(MULTIPLY, posStartMultiply), createToken(NUMBER, posStartNum2, 3),
+          createToken(R_BRACKET, posStartInnerRightBrack), createToken(POWER, posStartPower),
+          createToken(NUMBER, posStartNum3, 2), createToken(R_BRACKET, posStartOuterRightBrack),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 3) };
+        const binaryMultExp: ASTNode = {
+          token: createToken(MULTIPLY, posStartMultiply),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = { token: createToken(NUMBER, posStartNum3, 2) };
+        const binaryPowerExp: ASTNode = {
+          token: createToken(POWER, posStartPower),
+          leftChild: binaryMultExp,
+          rightChild: numberNode3
+        };
+
+        const unaryExp: ASTNode = {
+          token: createToken(MINUS, posStartMinus),
+          node: binaryPowerExp
+        };
+
+        const ast: ASTNode = {
+          token: createToken(IDENTIFIER, posStartVariable, 'variable'),
+          node: unaryExp
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        for (let i = 0; i < 12; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: 1 + (x = 10) * 2', () => {
+        const posStartNum1 = new PositionTracker(0, 1, 1);
+        const posStartPlus = new PositionTracker(2, 1, 3);
+        const posStartLeftBrack = new PositionTracker(4, 1, 5);
+        const posStartVariable = new PositionTracker(5, 1, 6);
+        const posStartEquals = new PositionTracker(7, 1, 8);
+        const posStartNum2 = new PositionTracker(9, 1, 10);
+        const posStartRightBrack = new PositionTracker(10, 1, 11);
+        const posStartMultiply = new PositionTracker(12, 1, 13);
+        const posStartNum3 = new PositionTracker(14, 1, 15);
+        const posStartEof = new PositionTracker(15, 1, 16);
+
+        const tokenList: Array<Token> = [
+          createToken(NUMBER, posStartNum1, 1), createToken(PLUS, posStartPlus),
+          createToken(L_BRACKET, posStartLeftBrack),
+          createToken(IDENTIFIER, posStartVariable, 'x'), createToken(EQUALS, posStartEquals),
+          createToken(NUMBER, posStartNum2, 10), createToken(R_BRACKET, posStartRightBrack),
+          createToken(MULTIPLY, posStartMultiply), createToken(NUMBER, posStartNum3, 2),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode2: ASTNode = { token: createToken(NUMBER, posStartNum2, 10) };
+        const varAssignNode: ASTNode = {
+          token: createToken(IDENTIFIER, posStartVariable, 'x'),
+          node: numberNode2
+        };
+
+        const numberNode3: ASTNode = { token: createToken(NUMBER, posStartNum3, 2) };
+        const binaryMultiplyExp: ASTNode = {
+          token: createToken(MULTIPLY, posStartMultiply),
+          leftChild: varAssignNode,
+          rightChild: numberNode3
+        };
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const ast: ASTNode = {
+          token: createToken(PLUS, posStartPlus),
+          leftChild: numberNode1,
+          rightChild: binaryMultiplyExp
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct error in parse result for expression: x =', () => {
+        const posStartVariable = new PositionTracker(0, 1, 1);
+        const posStartEquals = new PositionTracker(2, 1, 3);
+        const posStartEof = new PositionTracker(3, 1, 4);
+        const posEndEof = new PositionTracker(4, 1, 5);
+
+        const tokenList: Array<Token> = [
+          createToken(IDENTIFIER, posStartVariable, 'x'), createToken(EQUALS, posStartEquals),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected a number, identifier, '+', '-' or '('`, posStartEof, posEndEof);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct error in parse result for expression: 1 + x = 10 * 2', () => {
+        const posStartNum1 = new PositionTracker(0, 1, 1);
+        const posStartPlus = new PositionTracker(2, 1, 3);
+        const posStartVariable = new PositionTracker(4, 1, 5);
+        const posStartEquals = new PositionTracker(6, 1, 7);
+        const posEndEquals = new PositionTracker(7, 1, 8);
+        const posStartNum2 = new PositionTracker(8, 1, 9);
+        const posStartMultiply = new PositionTracker(10, 1, 11);
+        const posStartNum3 = new PositionTracker(12, 1, 13);
+        const posStartEof = new PositionTracker(13, 1, 14);
+
+        const tokenList: Array<Token> = [
+          createToken(NUMBER, posStartNum1, 1), createToken(PLUS, posStartPlus),
+          createToken(IDENTIFIER, posStartVariable, 'x'), createToken(EQUALS, posStartEquals),
+          createToken(NUMBER, posStartNum2, 10), createToken(MULTIPLY, posStartMultiply),
+          createToken(NUMBER, posStartNum3, 2), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = { token: createToken(NUMBER, posStartNum1, 1) };
+        const varAccessNode: ASTNode = { token: createToken(IDENTIFIER, posStartVariable, 'x') };
+        const currentAst: ASTNode = {
+          token: createToken(PLUS, posStartPlus),
+          leftChild: numberNode1,
+          rightChild: varAccessNode
+        };
+
+        const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/' or '^'`, posStartEquals, posEndEquals);
+
+        let expected = new ParseResult();
+        expected.success(currentAst);
+        expected.failure(error);
+
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+    });
+
+    describe('variable access tests', () => {
+      it('should return correct AST for statement: (1 + x) * (y - z)', () => {
+        const posStartLeftBrack1 = new PositionTracker(0, 1, 1);
+        const posStartNum = new PositionTracker(1, 1, 2);
+        const posStartPlus = new PositionTracker(3, 1, 4);
+        const posStartVariable1 = new PositionTracker(5, 1, 6);
+        const posStartRightBrack1 = new PositionTracker(6, 1, 7);
+        const posStartMultiply = new PositionTracker(8, 1, 9);
+        const posStartLeftBrack2 = new PositionTracker(10, 1, 11);
+        const posStartVariable2 = new PositionTracker(11, 1, 12);
+        const posStartMinus = new PositionTracker(13, 1, 14);
+        const posStartVariable3 = new PositionTracker(15, 1, 16);
+        const posStartRightBrack2 = new PositionTracker(16, 1, 17);
+        const posStartEof = new PositionTracker(17, 1, 18);
+
+        const tokenList: Array<Token> = [
+          createToken(L_BRACKET, posStartLeftBrack1), createToken(NUMBER, posStartNum, 1),
+          createToken(PLUS, posStartPlus), createToken(IDENTIFIER, posStartVariable1, 'x'),
+          createToken(R_BRACKET, posStartRightBrack1), createToken(MULTIPLY, posStartMultiply),
+          createToken(L_BRACKET, posStartLeftBrack2),
+          createToken(IDENTIFIER, posStartVariable2, 'y'), createToken(MINUS, posStartMinus),
+          createToken(IDENTIFIER, posStartVariable3, 'z'),
+          createToken(R_BRACKET, posStartRightBrack2), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode: ASTNode = { token: createToken(NUMBER, posStartNum, 1) };
+        const xVarAccessNode: ASTNode = { token: createToken(IDENTIFIER, posStartVariable1, 'x') };
+        const binaryPlusExp: ASTNode = {
+          token: createToken(PLUS, posStartPlus),
+          leftChild: numberNode,
+          rightChild: xVarAccessNode
+        };
+
+        const yVarAccessNode: ASTNode = { token: createToken(IDENTIFIER, posStartVariable2, 'y') };
+        const zVarAccessNode: ASTNode = { token: createToken(IDENTIFIER, posStartVariable3, 'z') };
+        const binaryMinusExp: ASTNode = {
+          token: createToken(MINUS, posStartMinus),
+          leftChild: yVarAccessNode,
+          rightChild: zVarAccessNode
+        };
+
+        const ast: ASTNode = {
+          token: createToken(MULTIPLY, posStartMultiply),
+          leftChild: binaryPlusExp,
+          rightChild: binaryMinusExp
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: x = y', () => {
+        const posStartVariable1 = new PositionTracker(0, 1, 1);
+        const posStartEquals = new PositionTracker(2, 1, 3);
+        const posStartVariable2 = new PositionTracker(4, 1, 5);
+        const posStartEof = new PositionTracker(5, 1, 6);
+
+        const tokenList: Array<Token> = [
+          createToken(IDENTIFIER, posStartVariable1, 'x'), createToken(EQUALS, posStartEquals),
+          createToken(IDENTIFIER, posStartVariable2, 'y'), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const yVarAccessNode: ASTNode = {
+          token: createToken(IDENTIFIER, posStartVariable2, 'y')
+        };
+        const ast: ASTNode = {
+          token: createToken(IDENTIFIER, posStartVariable1, 'x'),
+          node: yVarAccessNode
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: -variable', () => {
+        const posStartMinus = new PositionTracker(0, 1, 1);
+        const posStartVariable = new PositionTracker(1, 1, 2);
+        const posStartEof = new PositionTracker(9, 1, 10);
+
+        const tokenList: Array<Token> = [
+          createToken(MINUS, posStartMinus), createToken(IDENTIFIER, posStartVariable, 'variable'),
+          createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const varAccessNode: ASTNode = {
+          token: createToken(IDENTIFIER, posStartVariable, 'variable')
+        };
+        const ast: ASTNode = {
+          token: createToken(MINUS, posStartMinus),
+          node: varAccessNode
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct error in parse result for expression: x y', () => {
+        const posStartVariable1 = new PositionTracker(0, 1, 1);
+        const posStartVariable2 = new PositionTracker(2, 1, 3);
+        const posStartEof = new PositionTracker(3, 1, 4);
+
+        const tokenList: Array<Token> = [
+          createToken(IDENTIFIER, posStartVariable1, 'x'),
+          createToken(IDENTIFIER, posStartVariable2, 'y'), createToken(EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const xVarAccessNode: ASTNode = {
+          token: createToken(IDENTIFIER, posStartVariable1, 'x')
+        };
+        const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/' or '^'`,
+                                              posStartVariable2, posStartEof);
+
+        let expected = new ParseResult();
+        expected.success(xVarAccessNode);
+        expected.failure(error);
+
+        expected.registerAdvancement();
 
         expect(parseResult).toEqual(expected);
       });

--- a/src/app/models/var-access-node.ts
+++ b/src/app/models/var-access-node.ts
@@ -1,0 +1,6 @@
+import { ASTNode } from './ast-node';
+import { Token } from './token';
+
+export interface VarAccessNode extends ASTNode{
+  token: Token
+}

--- a/src/app/models/var-assign-node.ts
+++ b/src/app/models/var-assign-node.ts
@@ -1,0 +1,7 @@
+import { Token } from './token';
+import { ASTNode } from './ast-node';
+
+export interface VarAssignNode extends ASTNode {
+  token: Token,
+  node: ASTNode // The root node of the expression being assigned.
+}


### PR DESCRIPTION
Updated the parser to now be able to support building ASTs for variable assignment and variable access. Variable assignment works without needing any keywords, just like in Python. It also allows for variable assignment to be done within arithmetic expressions, for example: `1 + (variable = 1) + 2`. Note the brackets, which are needed for the precedence of variable assignment to take over and not cause any syntax errors. There has also been a refactoring of the `ParseResult` class to fix syntax errors being overwritten as the parser creates and returns the AST as a `ParseResult` from the recursive calls of the grammar functions. Finally, the lexer has also been refactored to allow for variable names with numbers such as `variable123` and also variables with underscores such as `variable_name` or `_variable`. Unit tests were also written for all these new additions.