### PR TITLE
feat(interpreter-evaluation): added interpreter evaluation for all current source code that can be parsed

### DIFF
--- a/src/app/constants/node-type.constants.ts
+++ b/src/app/constants/node-type.constants.ts
@@ -1,0 +1,5 @@
+export const NUMBER = 'NumberNode';
+export const BINARYOP = 'BinaryOpNode';
+export const UNARYOP = 'UnaryOpNode';
+export const VARACCESS = 'VarAccessNode';
+export const VARASSIGN = 'VarAssignNode';

--- a/src/app/data-types/number-type.spec.ts
+++ b/src/app/data-types/number-type.spec.ts
@@ -1,0 +1,137 @@
+import { RuntimeError } from './../logic/runtime-error';
+import { PositionTracker } from './../logic/position-tracker';
+import { NumberType } from './number-type';
+import { Context } from '../logic/context';
+
+describe('Number tests', () => {
+  it('should initialise with with passed value but with null position tracker and context', () => {
+    const number = new NumberType(10);
+
+    expect(number.getValue()).toEqual(10);
+    expect(number.getPosStart()).toEqual(null);
+    expect(number.getPosEnd()).toEqual(null);
+    expect(number.getContext()).toEqual(null);
+  });
+
+  describe('setter tests', () => {
+    it('should set posStart and posEnd when calling setPos', () => {
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
+      const number = new NumberType(10);
+
+      number.setPos(posStart, posEnd);
+
+      expect(number.getValue()).toEqual(10);
+      expect(number.getPosStart()).toEqual(posStart);
+      expect(number.getPosEnd()).toEqual(posEnd);
+      expect(number.getContext()).toEqual(null);
+    });
+
+    it('should set context when calling setContext', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+
+      number.setContext(context);
+
+      expect(number.getValue()).toEqual(10);
+      expect(number.getPosStart()).toEqual(null);
+      expect(number.getPosEnd()).toEqual(null);
+      expect(number.getContext()).toEqual(context);
+    });
+  });
+
+  describe('addBy tests', () => {
+    it('should return NumberType with added value and common context', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+      const otherNumber = new NumberType(5);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.addBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(15);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('subtractBy tests', () => {
+    it('should return NumberType with subtracted value and common context', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+      const otherNumber = new NumberType(5);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.subtractBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(5);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('multiplyBy tests', () => {
+    it('should return NumberType with multiplied value and common context', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+      const otherNumber = new NumberType(5);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.multiplyBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(50);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('divideBy tests', () => {
+    it('should return NumberType with divided value and common context', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+      const otherNumber = new NumberType(5);
+
+      number.setContext(context);
+      const [newNumber, _]: [NumberType, RuntimeError] = number.divideBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(2);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return runtime error when passing a NumberType with value 0', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+      const otherNumber = new NumberType(0);
+      const expectedRuntimeErr = new RuntimeError('Division by zero', otherNumber.getPosStart(),
+                                                                        otherNumber.getPosEnd(),
+                                                                      otherNumber.getContext());
+
+      number.setContext(context);
+      const [newNumber, error]: [NumberType, RuntimeError] = number.divideBy(otherNumber);
+
+      expect(newNumber).toEqual(null);
+      expect(error).toEqual(expectedRuntimeErr);
+    });
+  });
+
+  describe('poweredBy tests', () => {
+    it('should return NumberType with powered value and common context', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+      const otherNumber = new NumberType(5);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.poweredBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(100000);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+});

--- a/src/app/data-types/number-type.spec.ts
+++ b/src/app/data-types/number-type.spec.ts
@@ -40,6 +40,24 @@ describe('Number tests', () => {
     });
   });
 
+  describe('copy tests', () => {
+    it('should create a new copied instance of the NumberType when calling copy', () => {
+      const number = new NumberType(10);
+      const copiedNumber = number.copy();
+
+      expect(number).toEqual(copiedNumber);
+
+      const startPos = new PositionTracker(0, 1, 1);
+      const endPos = new PositionTracker(1, 1, 2);
+      copiedNumber.setPos(startPos, endPos);
+
+      expect(number.getPosStart()).toEqual(null);
+      expect(number.getPosEnd()).toEqual(null);
+      expect(copiedNumber.getPosStart()).toEqual(startPos);
+      expect(copiedNumber.getPosEnd()).toEqual(endPos);
+    });
+  });
+
   describe('addBy tests', () => {
     it('should return NumberType with added value and common context', () => {
       const context = new Context('<pseudo>');

--- a/src/app/data-types/number-type.spec.ts
+++ b/src/app/data-types/number-type.spec.ts
@@ -152,4 +152,395 @@ describe('Number tests', () => {
       expect(newNumber.getContext()).toEqual(context);
     });
   });
+
+  describe('equalityComparison tests', () => {
+    it('should return NumberType with a value of 1 when values are equal', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+      const otherNumber = new NumberType(10);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.equalityComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when values are not equal', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(10);
+      const otherNumber = new NumberType(11);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.equalityComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('lessThanComparison tests', () => {
+    it('should return NumberType with a value of 1 when number is less than otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(2);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.lessThanComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when number is equal to otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.lessThanComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when number is greater than otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(2);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.lessThanComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('greaterThanComparison tests', () => {
+    it('should return NumberType with a value of 1 when number is greater than otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(2);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.greaterThanComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when number is equal to otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.greaterThanComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when number is less than otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(2);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.greaterThanComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('lessThanOrEqualComparison tests', () => {
+    it('should return NumberType with a value of 1 when number is less than otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(2);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.lessThanOrEqualComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 1 when number is equal to otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.lessThanOrEqualComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when number is greater than otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(2);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.lessThanOrEqualComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('greaterThanOrEqualComparison tests', () => {
+    it('should return NumberType with a value of 1 when number is greater than otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(2);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.greaterThanOrEqualComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 1 when number is equal to otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.greaterThanOrEqualComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when number is less than otherNumber', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(2);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.greaterThanOrEqualComparison(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('andBy tests', () => {
+    it('should return NumberType with a value of 0 when number is 0 and otherNumber is 0', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(0);
+      const otherNumber = new NumberType(0);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.andBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when number is 1 and otherNumber is 0', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(0);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.andBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 0 when number is 0 and otherNumber is 1', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(0);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.andBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 1 when number is 1 and otherNumber is 1', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.andBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 1 when number is 100 and otherNumber is 10 (treated as 1s)', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(100);
+      const otherNumber = new NumberType(10);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.andBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('orBy tests', () => {
+    it('should return NumberType with a value of 0 when number is 0 and otherNumber is 0', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(0);
+      const otherNumber = new NumberType(0);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.orBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 1 when number is 1 and otherNumber is 0', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(0);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.orBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 1 when number is 0 and otherNumber is 1', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(0);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.orBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 1 when number is 1 and otherNumber is 1', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const otherNumber = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.orBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with a value of 1 when number is 100 and otherNumber is 10 (treated as 1s)', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(100);
+      const otherNumber = new NumberType(10);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.orBy(otherNumber);
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
+
+  describe('notted tests', () => {
+    it('should return NumberType with value of 0 when number is 1', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.notted();
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with value of 1 when number is 0', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(0);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.notted();
+
+      expect(newNumber.getValue()).toEqual(1);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+
+    it('should return NumberType with value of 0 when number is 100 (treated as 1)', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(100);
+
+      number.setContext(context);
+      const newNumber: NumberType = number.notted();
+
+      expect(newNumber.getValue()).toEqual(0);
+      expect(newNumber.getPosStart()).toEqual(null);
+      expect(newNumber.getPosEnd()).toEqual(null);
+      expect(newNumber.getContext()).toEqual(context);
+    });
+  });
 });

--- a/src/app/data-types/number-type.ts
+++ b/src/app/data-types/number-type.ts
@@ -1,0 +1,70 @@
+import { Context } from './../logic/context';
+import { RuntimeError } from './../logic/runtime-error';
+import { PositionTracker } from './../logic/position-tracker';
+
+export class NumberType {
+
+  private posStart: PositionTracker;
+  private posEnd: PositionTracker;
+  private context;
+
+  constructor(private value: number) {
+    this.setPos(null, null);
+    this.setContext(null);
+  }
+
+  public setPos(start: PositionTracker, end: PositionTracker): NumberType {
+    this.posStart = start;
+    this.posEnd = end;
+
+    return this;
+  }
+
+  public setContext(context: Context): NumberType {
+    this.context = context;
+    return this;
+  }
+
+  public addBy(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      return new NumberType(this.value + other.getValue()).setContext(this.context);
+    }
+  }
+
+  public subtractBy(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      return new NumberType(this.value - other.getValue()).setContext(this.context);
+    }
+  }
+
+  public multiplyBy(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      return new NumberType(this.value * other.getValue()).setContext(this.context);
+    }
+  }
+
+  public divideBy(other: NumberType): [NumberType, RuntimeError] {
+    if (other instanceof NumberType) {
+      if (other.getValue() === 0) {
+        return [null, new RuntimeError('Division by zero', other.getPosStart(),
+                                        other.getPosEnd(), other.getContext())];
+      }
+
+      return [new NumberType(this.value / other.getValue()).setContext(this.context), null];
+    }
+  }
+
+  public poweredBy(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      return new NumberType(this.value ** other.getValue()).setContext(this.context);
+    }
+  }
+
+  public getValue(): number { return this.value; }
+
+  public getPosStart(): PositionTracker { return this.posStart; }
+
+  public getPosEnd(): PositionTracker { return this.posEnd; }
+
+  public getContext(): Context { return this.context; }
+}

--- a/src/app/data-types/number-type.ts
+++ b/src/app/data-types/number-type.ts
@@ -60,6 +60,15 @@ export class NumberType {
     }
   }
 
+  public copy(): NumberType {
+    const number = new NumberType(this.value);
+
+    number.setPos(this.posStart, this.posEnd);
+    number.setContext(this.context);
+
+    return number;
+  }
+
   public getValue(): number { return this.value; }
 
   public getPosStart(): PositionTracker { return this.posStart; }

--- a/src/app/data-types/number-type.ts
+++ b/src/app/data-types/number-type.ts
@@ -2,6 +2,9 @@ import { Context } from './../logic/context';
 import { RuntimeError } from './../logic/runtime-error';
 import { PositionTracker } from './../logic/position-tracker';
 
+/**
+ * Used to represent both numbers and boolean primitives in Pseudo.
+ */
 export class NumberType {
 
   private posStart: PositionTracker;
@@ -58,6 +61,71 @@ export class NumberType {
     if (other instanceof NumberType) {
       return new NumberType(this.value ** other.getValue()).setContext(this.context);
     }
+  }
+
+  public equalityComparison(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      // This expression is most performant way to convert from boolean to number in Javascript.
+      const convertedBoolToNum: number = this.value === other.getValue() ? 1 : 0;
+      return new NumberType(convertedBoolToNum).setContext(this.context);
+    }
+  }
+
+  public lessThanComparison(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      // This expression is most performant way to convert from boolean to number in Javascript.
+      const convertedBoolToNum: number = this.value < other.getValue() ? 1 : 0;
+      return new NumberType(convertedBoolToNum).setContext(this.context);
+    }
+  }
+
+  public greaterThanComparison(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      // This expression is most performant way to convert from boolean to number in Javascript.
+      const convertedBoolToNum: number = this.value > other.getValue() ? 1 : 0;
+      return new NumberType(convertedBoolToNum).setContext(this.context);
+    }
+  }
+
+  public lessThanOrEqualComparison(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      // This expression is most performant way to convert from boolean to number in Javascript.
+      const convertedBoolToNum: number = this.value <= other.getValue() ? 1 : 0;
+      return new NumberType(convertedBoolToNum).setContext(this.context);
+    }
+  }
+
+  public greaterThanOrEqualComparison(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      // This expression is most performant way to convert from boolean to number in Javascript.
+      const convertedBoolToNum: number = this.value >= other.getValue() ? 1 : 0;
+      return new NumberType(convertedBoolToNum).setContext(this.context);
+    }
+  }
+
+  public andBy(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      // This expression is most performant way to convert from boolean to number in Javascript.
+      const convertedValue: number = this.value !== 0 ? 1 : 0;
+      const convertedOther: number = other.getValue() !== 0 ? 1 : 0;
+      const convertedBoolToNum: number = convertedValue && convertedOther;
+      return new NumberType(convertedBoolToNum).setContext(this.context);
+    }
+  }
+
+  public orBy(other: NumberType): NumberType {
+    if (other instanceof NumberType) {
+      // This expression is most performant way to convert from boolean to number in Javascript.
+      const convertedValue: number = this.value !== 0 ? 1 : 0;
+      const convertedOther: number = other.getValue() !== 0 ? 1 : 0;
+      const convertedBoolToNum: number = convertedValue || convertedOther;
+      return new NumberType(convertedBoolToNum).setContext(this.context);
+    }
+  }
+
+  public notted(): NumberType {
+    const convertedValueToBool: number = this.value === 0 ? 1 : 0;
+    return new NumberType(convertedValueToBool).setContext(this.context);
   }
 
   public copy(): NumberType {

--- a/src/app/logic/context.spec.ts
+++ b/src/app/logic/context.spec.ts
@@ -1,0 +1,22 @@
+import { PositionTracker } from './position-tracker';
+import { Context } from "./context";
+
+describe('Context tests', () => {
+  it('should initialise context with passed contextName and null for parent and parentEntryPos if not passed', () => {
+    const context = new Context('<pseudo>');
+
+    expect(context.getContextName()).toEqual('<pseudo>');
+    expect(context.getParent()).toEqual(null);
+    expect(context.getParentEntryPos()).toEqual(null);
+  });
+
+  it('should initialise context with passed contextName and null for parent and parentEntryPos if not passed', () => {
+    const parentContext = new Context('<pseudo>');
+    const parentPos = new PositionTracker(10, 2, 3);
+    const context = new Context('function', parentContext, parentPos);
+
+    expect(context.getContextName()).toEqual('function');
+    expect(context.getParent()).toEqual(parentContext);
+    expect(context.getParentEntryPos()).toEqual(parentPos);
+  });
+});

--- a/src/app/logic/context.ts
+++ b/src/app/logic/context.ts
@@ -1,0 +1,20 @@
+import { PositionTracker } from './position-tracker';
+/**
+ * This handles the scope of access to variables in the current step of the runtime.
+ */
+export class Context {
+
+  private parent: Context = null; // Defines the access scope during runtime.
+  private parentEntryPos: PositionTracker = null; // For runtime error tracebacks.
+
+  constructor(private contextName: string, parent?: Context, parentEntryPos?: PositionTracker) {
+    if (parent !== undefined) { this.parent = parent; }
+    if (parentEntryPos !== undefined) { this.parentEntryPos = parentEntryPos; }
+  }
+
+  public getContextName(): string { return this.contextName; }
+
+  public getParent(): Context { return this.parent; }
+
+  public getParentEntryPos(): PositionTracker { return this.parentEntryPos; }
+}

--- a/src/app/logic/context.ts
+++ b/src/app/logic/context.ts
@@ -1,4 +1,6 @@
+import { SymbolTable } from './symbol-table';
 import { PositionTracker } from './position-tracker';
+
 /**
  * This handles the scope of access to variables in the current step of the runtime.
  */
@@ -6,6 +8,7 @@ export class Context {
 
   private parent: Context = null; // Defines the access scope during runtime.
   private parentEntryPos: PositionTracker = null; // For runtime error tracebacks.
+  public symbolTable: SymbolTable = null;
 
   constructor(private contextName: string, parent?: Context, parentEntryPos?: PositionTracker) {
     if (parent !== undefined) { this.parent = parent; }

--- a/src/app/logic/error.ts
+++ b/src/app/logic/error.ts
@@ -2,8 +2,8 @@ import { PositionTracker } from './position-tracker';
 
 export class Error {
 
-    constructor(private type: string, private posStart: PositionTracker,
-                private posEnd: PositionTracker, private details?: string) {}
+    constructor(protected type: string, protected posStart: PositionTracker,
+                protected posEnd: PositionTracker, protected details?: string) {}
 
     public getErrorMessage(): string {
 

--- a/src/app/logic/parse-result.spec.ts
+++ b/src/app/logic/parse-result.spec.ts
@@ -3,7 +3,8 @@ import { ASTNode } from './../models/ast-node';
 import { ParseResult } from './parse-result';
 import { InvalidSyntaxError } from './invalid-syntax-error';
 import { Token } from '../models/token';
-import { EQUALS } from '../constants/token-type.constants';
+import { NUMBER } from '../constants/token-type.constants';
+import * as NodeTypes from '../constants/node-type.constants';
 
 describe('ParseResult tests', () => {
   it('should initialise node and error attributes as null and advanceCount to 0', () => {
@@ -16,7 +17,7 @@ describe('ParseResult tests', () => {
 
   describe('success tests', () => {
     it('should return a node instance and null error when using getter, after calling success', () => {
-      const astNode: ASTNode = createASTNode(EQUALS);
+      const astNode: ASTNode = createASTNode(NodeTypes.NUMBER, NUMBER);
       const parseResult = new ParseResult();
 
       parseResult.success(astNode);
@@ -60,7 +61,7 @@ describe('ParseResult tests', () => {
     });
 
     it('should return node in passed in parse result and assign node if node exists in passed parse result', () => {
-      const astNode: ASTNode = createASTNode(EQUALS);
+      const astNode: ASTNode = createASTNode(NodeTypes.NUMBER, NUMBER);
       const nodeParseResult = new ParseResult();
       nodeParseResult.success(astNode);
 
@@ -99,7 +100,7 @@ describe('ParseResult tests', () => {
   });
 });
 
-function createASTNode(tokenType: string): ASTNode {
+function createASTNode(nodeType: string, tokenType: string): ASTNode {
   const startPos = new PositionTracker(0, 1, 1);
   const endPos = startPos.copy();
   endPos.advance();
@@ -110,7 +111,7 @@ function createASTNode(tokenType: string): ASTNode {
     positionEnd: endPos
   };
 
-  const astNode: ASTNode = { token: equalsToken };
+  const astNode: ASTNode = { nodeType: nodeType, token: equalsToken };
 
   return astNode;
 }

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -4,6 +4,7 @@ import { Parser } from './parser';
 import { PositionTracker } from './position-tracker';
 import { Token } from '../models/token';
 import * as TokenTypes from '../constants/token-type.constants';
+import * as NodeTypes from '../constants/node-type.constants';
 import { ParseResult } from './parse-result';
 
 describe('Parser tests', () => {
@@ -19,7 +20,10 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode: ASTNode = { token: createToken(TokenTypes.NUMBER, posStart, 10) };
+        const numberNode: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStart, 10)
+        };
         let expected = new ParseResult();
         expected = expected.success(numberNode);
 
@@ -38,7 +42,10 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode: ASTNode = { token: createToken(TokenTypes.NUMBER, posStart, 3.14) };
+        const numberNode: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStart, 3.14)
+        };
         let expected = new ParseResult();
         expected = expected.success(numberNode);
 
@@ -61,8 +68,12 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNumber, 1) };
+        const numberNode: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNumber, 1)
+        };
         const unaryNode: ASTNode = {
+          nodeType: NodeTypes.UNARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus), node: numberNode
         };
         let expected = new ParseResult();
@@ -88,8 +99,12 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNumber, 1) };
+        const numberNode: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNumber, 1)
+        };
         const unaryNode: ASTNode = {
+          nodeType: NodeTypes.UNARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus), node: numberNode
         };
         let expected = new ParseResult();
@@ -117,9 +132,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 3) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 4) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 3)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 4)
+        };
         const binaryNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -149,9 +171,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 10) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 9) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 10)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 9)
+        };
         const binaryNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -181,9 +210,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 8) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 4) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 8)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 4)
+        };
         const binaryNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MULTIPLY, posStartMultiply),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -213,9 +249,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 8) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 4) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 8)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 4)
+        };
         const binaryNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.DIVIDE, posStartDivide),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -245,9 +288,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 3) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 2) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 3)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
         const binaryNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.POWER, posStartPower),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -297,23 +347,38 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 2) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
         const leftBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: numberNode2
         };
 
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 4) };
-        const numberNode4: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum4, 1) };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 4)
+        };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 1)
+        };
         const rightBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           leftChild: numberNode3,
           rightChild: numberNode4
         };
 
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MULTIPLY, posStartMultiply),
           leftChild: leftBinaryExp,
           rightChild: rightBinaryExp
@@ -351,17 +416,28 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 2) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
         const binaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: numberNode2
         };
 
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 3) };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 3)
+        };
 
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.DIVIDE, posStartDivide),
           leftChild: binaryExp,
           rightChild: numberNode3
@@ -399,23 +475,38 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 2) };
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 3) };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 3)
+        };
         const powerBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.POWER, posStartPower),
           leftChild: numberNode2,
           rightChild: numberNode3
         };
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
         const plusBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: powerBinaryExp
         };
 
-        const numberNode4: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum4, 4) };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 4)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           leftChild: plusBinaryExp,
           rightChild: numberNode4
@@ -447,15 +538,23 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 2) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 3) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 2)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 3)
+        };
         const powerBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.POWER, posStartPower),
           leftChild: numberNode1,
           rightChild: numberNode2
         };
 
         const ast: ASTNode = {
+          nodeType: NodeTypes.UNARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           node: powerBinaryExp
         };
@@ -496,23 +595,38 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 2) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
         const plusBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: numberNode2
         };
 
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 3) };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 3)
+        };
         const powerBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.POWER, posStartPower),
           leftChild: plusBinaryExp,
           rightChild: numberNode3
         };
 
-        const numberNode4: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum4, 4) };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 4)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           leftChild: powerBinaryExp,
           rightChild: numberNode4
@@ -564,29 +678,45 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 2) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
         const leftBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: numberNode2
         };
 
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 4) };
-        const numberNode4: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum4, 1) };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 4)
+        };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 1)
+        };
         const rightBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           leftChild: numberNode3,
           rightChild: numberNode4
         };
 
         const outerBinaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MULTIPLY, posStartMultiply),
           leftChild: leftBinaryExp,
           rightChild: rightBinaryExp
         };
 
         const unaryExp: ASTNode = {
+          nodeType: NodeTypes.UNARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinusUnary),
           node: outerBinaryExp
         };
@@ -613,7 +743,10 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 10) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 10)
+        };
         const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', ` +
                                              `'>', '<=', '>=', 'AND' or 'OR'`, posStartNum2,
                                               posStartEof);
@@ -649,9 +782,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 2) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
         const binaryExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -725,8 +865,12 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable, 'variable'),
           node: numberNode1
         };
@@ -767,22 +911,34 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 3) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 3)
+        };
         const binaryMultExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MULTIPLY, posStartMultiply),
           leftChild: numberNode1,
           rightChild: numberNode2
         };
 
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 2) };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 2)
+        };
         const binaryPowerExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.POWER, posStartPower),
           leftChild: binaryMultExp,
           rightChild: numberNode3
         };
 
         const ast: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable, 'variable'),
           node: binaryPowerExp
         };
@@ -829,27 +985,40 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 3) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 3)
+        };
         const binaryMultExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MULTIPLY, posStartMultiply),
           leftChild: numberNode1,
           rightChild: numberNode2
         };
 
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 2) };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 2)
+        };
         const binaryPowerExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.POWER, posStartPower),
           leftChild: binaryMultExp,
           rightChild: numberNode3
         };
 
         const unaryExp: ASTNode = {
+          nodeType: NodeTypes.UNARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           node: binaryPowerExp
         };
 
         const ast: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable, 'variable'),
           node: unaryExp
         };
@@ -890,21 +1059,33 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 10) };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 10)
+        };
         const varAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable, 'x'),
           node: numberNode2
         };
 
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 2) };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 2)
+        };
         const binaryMultiplyExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MULTIPLY, posStartMultiply),
           leftChild: varAssignNode,
           rightChild: numberNode3
         };
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: binaryMultiplyExp
@@ -969,11 +1150,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
         const varAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable, 'x')
         };
         const currentAst: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode1,
           rightChild: varAccessNode
@@ -1026,29 +1212,38 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum, 1) };
+        const numberNode: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum, 1)
+        };
         const xVarAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable1, 'x')
         };
         const binaryPlusExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.PLUS, posStartPlus),
           leftChild: numberNode,
           rightChild: xVarAccessNode
         };
 
         const yVarAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable2, 'y')
         };
         const zVarAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable3, 'z')
         };
         const binaryMinusExp: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           leftChild: yVarAccessNode,
           rightChild: zVarAccessNode
         };
 
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.MULTIPLY, posStartMultiply),
           leftChild: binaryPlusExp,
           rightChild: binaryMinusExp
@@ -1079,9 +1274,11 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const yVarAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable2, 'y')
         };
         const ast: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable1, 'x'),
           node: yVarAccessNode
         };
@@ -1109,9 +1306,11 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const varAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable, 'variable')
         };
         const ast: ASTNode = {
+          nodeType: NodeTypes.UNARYOP,
           token: createToken(TokenTypes.MINUS, posStartMinus),
           node: varAccessNode
         };
@@ -1139,6 +1338,7 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const xVarAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable1, 'x')
         };
         const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', ` +
@@ -1172,9 +1372,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 1)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.EQUALITY, posStartEquality),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -1204,9 +1411,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 10) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 10)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 1)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.G_THAN, posStartGThan),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -1236,9 +1450,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 2) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.L_THAN, posStartLThan),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -1268,9 +1489,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 1)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.G_THAN_EQ, posStartGThanEq),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -1300,9 +1528,16 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 1) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 1)
+        };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.L_THAN_EQ, posStartLThanEq),
           leftChild: numberNode1,
           rightChild: numberNode2
@@ -1333,12 +1568,15 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const boolAccessNode1: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE')
         };
         const boolAccessNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartFalse, 'FALSE')
         };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.KEYWORD, posStartAnd, 'AND'),
           leftChild: boolAccessNode1,
           rightChild: boolAccessNode2
@@ -1369,12 +1607,15 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const boolAccessNode1: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE')
         };
         const boolAccessNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartFalse, 'FALSE')
         };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.KEYWORD, posStartOr, 'OR'),
           leftChild: boolAccessNode1,
           rightChild: boolAccessNode2
@@ -1407,17 +1648,21 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const boolAccessNode1: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE')
         };
         const boolAccessNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartFalse, 'FALSE')
         };
         const boolAndExpr: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.KEYWORD, posStartAnd, 'AND'),
           leftChild: boolAccessNode1,
           rightChild: boolAccessNode2
         };
         const ast: ASTNode = {
+          nodeType: NodeTypes.UNARYOP,
           token: createToken(TokenTypes.KEYWORD, posStartNot, 'NOT'),
           node: boolAndExpr
         };
@@ -1476,45 +1721,62 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const numberNode1: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum1, 10) };
-        const numberNode2: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum2, 1) };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 10)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 1)
+        };
         const firstCondExpr: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.G_THAN, posStartGThan),
           leftChild: numberNode1,
           rightChild: numberNode2
         };
 
-        const numberNode3: ASTNode = { token: createToken(TokenTypes.NUMBER, posStartNum3, 5) };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 5)
+        };
         const varXAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x')
         };
         const secondCondExpr: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.L_THAN, posStartLThan),
           leftChild: numberNode3,
           rightChild: varXAccessNode
         };
 
         const orExpr: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.KEYWORD, posStartOr, 'OR'),
           leftChild: firstCondExpr,
           rightChild: secondCondExpr
         };
 
         const trueAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE')
         };
         const andExpr: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.KEYWORD, posStartAnd, 'AND'),
           leftChild: trueAccessNode,
           rightChild: orExpr
         };
 
         const notExpr: ASTNode = {
+          nodeType: NodeTypes.UNARYOP,
           token: createToken(TokenTypes.KEYWORD, posStartNot, 'NOT'),
           node: andExpr
         };
 
         const ast: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
           token: createToken(TokenTypes.IDENTIFIER, posStartVar, 'var'),
           node: notExpr
         };
@@ -1544,7 +1806,10 @@ describe('Parser tests', () => {
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const trueNode: ASTNode = { token: createToken(TokenTypes.IDENTIFIER, posStartTrue, 'true') };
+        const trueNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartTrue, 'true')
+        };
         const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', ` +
                                              `'>', '<=', '>=', 'AND' or 'OR'`, posStartAnd,
                                              posEndAnd);
@@ -1583,17 +1848,21 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const falseNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartFalse, 'FALSE')
         };
         const varAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
           token: createToken(TokenTypes.IDENTIFIER, posStartVar, 'var'),
           node: falseNode
         };
 
         const trueNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE')
         };
         const ast: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
           token: createToken(TokenTypes.KEYWORD, posStartAnd, 'AND'),
           leftChild: trueNode,
           rightChild: varAssignNode

--- a/src/app/logic/parser.ts
+++ b/src/app/logic/parser.ts
@@ -7,6 +7,7 @@ import { NumberNode } from './../models/number-node';
 import { ASTNode } from '../models/ast-node';
 import { Token } from '../models/token';
 import * as TokenTypes from '../constants/token-type.constants';
+import * as NodeTypes from '../constants/node-type.constants';
 import { UnaryOpNode } from '../models/unary-op-node';
 
 /**
@@ -77,6 +78,7 @@ export class Parser {
       else { rightNode = parseResult.register(this.factor()); }
 
       leftNode = {
+        nodeType: NodeTypes.BINARYOP,
         token: opToken,
         leftChild: leftNode,
         rightChild: rightNode
@@ -94,14 +96,14 @@ export class Parser {
     if (tok.type === TokenTypes.NUMBER) {
       parseResult.registerAdvancement();
       this.advance();
-      let numberNode: NumberNode = {token: tok};
+      let numberNode: NumberNode = { nodeType: NodeTypes.NUMBER, token: tok };
       return parseResult.success(numberNode);
     }
     else if (tok.type === TokenTypes.IDENTIFIER || tok.value === 'TRUE' ||
                                                     tok.value === 'FALSE') {
       parseResult.registerAdvancement();
       this.advance();
-      const varAccessNode: VarAccessNode = { token: tok };
+      const varAccessNode: VarAccessNode = { nodeType: NodeTypes.VARACCESS, token: tok };
       return parseResult.success(varAccessNode);
     }
     else if (tok.type === TokenTypes.L_BRACKET) {
@@ -147,7 +149,7 @@ export class Parser {
 
       if (parseResult.getError() !== null) { return parseResult; }
 
-      const unaryOpNode: UnaryOpNode = {token: tok, node: factor};
+      const unaryOpNode: UnaryOpNode = { nodeType: NodeTypes.UNARYOP, token: tok, node: factor };
       return parseResult.success(unaryOpNode);
     }
 
@@ -180,7 +182,7 @@ export class Parser {
 
       if (parseResult.getError() !== null) { return parseResult; }
 
-      const unaryNode: UnaryOpNode = {token: opToken, node: node};
+      const unaryNode: UnaryOpNode = {nodeType: NodeTypes.UNARYOP, token: opToken, node: node};
       return parseResult.success(unaryNode);
     }
 
@@ -213,7 +215,11 @@ export class Parser {
         const expr = parseResult.register(this.expr());
         if (parseResult.getError() !== null) { return parseResult; }
 
-        const varAssignNode: VarAssignNode = { token: tok, node: expr };
+        const varAssignNode: VarAssignNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: tok,
+          node: expr
+        };
         return parseResult.success(varAssignNode);
       }
     }

--- a/src/app/logic/runtime-error.spec.ts
+++ b/src/app/logic/runtime-error.spec.ts
@@ -1,0 +1,44 @@
+import { RuntimeError } from './runtime-error';
+import { Context } from './context';
+import { PositionTracker } from './position-tracker';
+
+describe('RuntimeError tests', () => {
+  describe('getErrorMessage tests', () => {
+    it('should have error message with single traceback for null parent context for runtime error', () => {
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
+      const context = new Context('<pseudo>');
+      const runtimeError = new RuntimeError('Division by zero', posStart, posEnd, context);
+      const positionDetails = `At line: ${posStart.getLine()} column: ` +
+                              `${posStart.getColumn()} and ends at line: ` +
+                              `${posEnd.getLine()} column: ${posEnd.getColumn()}`;
+
+      const expected = `Traceback (most recent call last):\nLine ${posStart.getLine() + 1}, ` +
+                       `in ${context.getContextName()}\nRuntime Error: Division by zero\n` +
+                       `${positionDetails}`;
+
+      expect(runtimeError.getErrorMessage()).toEqual(expected);
+    });
+
+    it('should have error message with full traceback for parented context for runtime error', () => {
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
+      const posStartParent = new PositionTracker(25, 5, 1);
+      const parentContext = new Context('<pseudo>');
+      const context = new Context('function', parentContext, posStartParent);
+      const runtimeError = new RuntimeError('Division by zero', posStart, posEnd, context);
+      const positionDetails = `At line: ${posStart.getLine()} column: ` +
+                              `${posStart.getColumn()} and ends at line: ` +
+                              `${posEnd.getLine()} column: ${posEnd.getColumn()}`;
+
+      const tracebackDetails = `Traceback (most recent call last):\nLine ` +
+                               `${posStartParent.getLine() + 1}, in ` +
+                               `${parentContext.getContextName()}\nLine ` +
+                               `${posStart.getLine() + 1}, in ${context.getContextName()}\n`;
+
+      const expected = `${tracebackDetails}Runtime Error: Division by zero\n${positionDetails}`;
+
+      expect(runtimeError.getErrorMessage()).toEqual(expected);
+    });
+  });
+});

--- a/src/app/logic/runtime-error.ts
+++ b/src/app/logic/runtime-error.ts
@@ -1,0 +1,35 @@
+import { Context } from './context';
+import { Error } from './error';
+import { PositionTracker } from './position-tracker';
+
+export class RuntimeError extends Error {
+  constructor(details: string, posStart: PositionTracker, posEnd: PositionTracker,
+              private context: Context) {
+    super('Runtime Error', posStart, posEnd, details);
+  }
+
+  public getErrorMessage(): string {
+    const positionDetails = `At line: ${this.posStart.getLine()} column: ` +
+                            `${this.posStart.getColumn()} and ends at line: ` +
+                            `${this.posEnd.getLine()} column: ${this.posEnd.getColumn()}`;
+
+    let result = this.generateTraceback();
+    result += `${this.type}: ${this.details}\n${positionDetails}`;
+
+    return result;
+  }
+
+  private generateTraceback(): string {
+    let result = '';
+    let pos = this.posStart;
+    let ctx = this.context;
+
+    while (ctx !== null) {
+      result = `Line ${pos.getLine() + 1}, in ${ctx.getContextName()}\n` + result;
+      pos = ctx.getParentEntryPos();
+      ctx = ctx.getParent();
+    }
+
+    return 'Traceback (most recent call last):\n' + result;
+  }
+}

--- a/src/app/logic/runtime-result.spec.ts
+++ b/src/app/logic/runtime-result.spec.ts
@@ -1,0 +1,74 @@
+import { Context } from './context';
+import { PositionTracker } from './position-tracker';
+import { RuntimeError } from './runtime-error';
+import { NumberType } from './../data-types/number-type';
+import { RuntimeResult } from './runtime-result';
+
+describe('RuntimeResult tests', () => {
+  it('should initialise value and error attributes as null', () => {
+    const parseResult = new RuntimeResult();
+
+    expect(parseResult.getError()).toEqual(null);
+    expect(parseResult.getValue()).toEqual(null);
+  });
+
+  describe('success tests', () => {
+    it('should return a value instance and null error when using getter, after calling success', () => {
+      const number = new NumberType(10);
+      const runtimeResult = new RuntimeResult();
+
+      const returnedRuntimeResult: RuntimeResult = runtimeResult.success(number);
+
+      expect(returnedRuntimeResult).toEqual(runtimeResult);
+      expect(runtimeResult.getValue()).toEqual(number);
+      expect(runtimeResult.getError()).toEqual(null);
+    });
+  });
+
+  describe('failure tests', () => {
+    it('should return an error instance and null value when using getter, after calling failure', () => {
+      const posStart = new PositionTracker(4, 1, 5);
+      const posEnd = new PositionTracker(5, 1, 6);
+      const context = new Context('<pseudo>');
+      const runtimeError = new RuntimeError('Division by zero', posStart, posEnd, context);
+      const runtimeResult = new RuntimeResult();
+
+      const returnedRuntimeResult: RuntimeResult = runtimeResult.failure(runtimeError);
+
+      expect(returnedRuntimeResult).toEqual(runtimeResult);
+      expect(runtimeResult.getValue()).toEqual(null);
+      expect(runtimeResult.getError()).toEqual(runtimeError);
+    });
+  });
+
+  describe('register tests', () => {
+    it('should return value in runtime result if runtime result has no errors', () => {
+      const number = new NumberType(10);
+      const runtimeResult = new RuntimeResult();
+      const otherRuntimeResult = new RuntimeResult();
+
+      otherRuntimeResult.success(number);
+      const returnedValue: NumberType = runtimeResult.register(otherRuntimeResult);
+
+      expect(returnedValue).toEqual(number);
+      expect(runtimeResult.getValue()).toEqual(null);
+      expect(runtimeResult.getError()).toEqual(null);
+    });
+
+    it('should return value in runtime result if runtime result has errors and assign the error attribute', () => {
+      const posStart = new PositionTracker(4, 1, 5);
+      const posEnd = new PositionTracker(5, 1, 6);
+      const context = new Context('<pseudo>');
+      const runtimeError = new RuntimeError('Division by zero', posStart, posEnd, context);
+      const runtimeResult = new RuntimeResult();
+      const otherRuntimeResult = new RuntimeResult();
+
+      otherRuntimeResult.failure(runtimeError);
+      const returnedValue: NumberType = runtimeResult.register(otherRuntimeResult);
+
+      expect(returnedValue).toEqual(null);
+      expect(runtimeResult.getValue()).toEqual(null);
+      expect(runtimeResult.getError()).toEqual(runtimeError);
+    });
+  });
+});

--- a/src/app/logic/runtime-result.ts
+++ b/src/app/logic/runtime-result.ts
@@ -1,0 +1,26 @@
+import { RuntimeError } from './runtime-error';
+import { NumberType } from './../data-types/number-type';
+
+export class RuntimeResult {
+  private value: NumberType = null;
+  private error: RuntimeError = null;
+
+  public register(result: RuntimeResult): NumberType {
+    if (result.getError() !== null) { this.error = result.getError(); }
+    return result.value;
+  }
+
+  public success(value: NumberType): RuntimeResult {
+    this.value = value;
+    return this;
+  }
+
+  public failure(error: RuntimeError): RuntimeResult {
+    this.error = error;
+    return this;
+  }
+
+  public getValue(): NumberType { return this.value; }
+
+  public getError(): RuntimeError { return this.error; }
+}

--- a/src/app/logic/symbol-table.spec.ts
+++ b/src/app/logic/symbol-table.spec.ts
@@ -1,0 +1,73 @@
+import { NumberType } from './../data-types/number-type';
+import { SymbolTable } from './symbol-table';
+
+describe('SymbolTable tests', () => {
+  it('should initialise with an empty symbols map and null parent', () => {
+    const symbolTable = new SymbolTable();
+    const expectedSymbols = new Map<string, NumberType>();
+    const expectedParentTable: SymbolTable = null;
+
+    expect(symbolTable.getSymbols()).toEqual(expectedSymbols);
+    expect(symbolTable.getParent()).toEqual(expectedParentTable);
+  });
+
+  describe('set and get tests', () => {
+    it('should return undefined value for trying to get from an empty SymbolTable', () => {
+      const symbolTable = new SymbolTable();
+      const value: NumberType = symbolTable.get('variable');
+
+      expect(value).toEqual(undefined);
+    });
+
+    it('should return correct value for getting an existing value in the SymbolTable', () => {
+      const symbolTable = new SymbolTable();
+      symbolTable.set('variable', new NumberType(10));
+      symbolTable.set('variable2', new NumberType(20));
+      symbolTable.set('variable3', new NumberType(100));
+
+      const value1: NumberType = symbolTable.get('variable');
+      const value2: NumberType = symbolTable.get('variable2');
+      const value3: NumberType = symbolTable.get('variable3');
+      const value4: NumberType = symbolTable.get('var');
+
+      expect(value1).toEqual(new NumberType(10));
+      expect(value2).toEqual(new NumberType(20));
+      expect(value3).toEqual(new NumberType(100));
+      expect(value4).toEqual(undefined);
+    });
+  });
+
+  describe('remove tests', () => {
+    it('should not do anything when calling remove on an empty SymbolTable', () => {
+      const symbolTable = new SymbolTable();
+      const expectedSymbols = new Map<string, NumberType>();
+      const expectedParentTable: SymbolTable = null;
+
+      expect(symbolTable.getSymbols()).toEqual(expectedSymbols);
+      expect(symbolTable.getParent()).toEqual(expectedParentTable);
+
+      symbolTable.remove('variable'); // Remove non-existent entry.
+
+      // Should change anything in the symbolTable. Should remain empty.
+      expect(symbolTable.getSymbols()).toEqual(expectedSymbols);
+      expect(symbolTable.getParent()).toEqual(expectedParentTable);
+    });
+
+    it('should remove the correct entry from the SymbolTable when passing in an existing variable name to remove', () => {
+      const symbolTable = new SymbolTable();
+      symbolTable.set('variable', new NumberType(10));
+      symbolTable.set('variable2', new NumberType(20));
+      symbolTable.set('variable3', new NumberType(100));
+
+      symbolTable.remove('variable');
+
+      const value1: NumberType = symbolTable.get('variable');
+      const value2: NumberType = symbolTable.get('variable2');
+      const value3: NumberType = symbolTable.get('variable3');
+
+      expect(value1).toEqual(undefined);
+      expect(value2).toEqual(new NumberType(20));
+      expect(value3).toEqual(new NumberType(100));
+    });
+  });
+});

--- a/src/app/logic/symbol-table.ts
+++ b/src/app/logic/symbol-table.ts
@@ -1,0 +1,24 @@
+import { NumberType } from './../data-types/number-type';
+
+export class SymbolTable {
+
+  private symbols: Map<string, NumberType> = new Map<string, NumberType>();
+  private parent: SymbolTable = null;
+
+  public get(variableName: string): NumberType {
+    const value: NumberType = this.symbols.get(variableName);
+    if (value === undefined && this.parent !== null) { return this.parent.get(variableName); }
+
+    return value;
+  }
+
+  public set(variableName: string, value: NumberType): void {
+    this.symbols.set(variableName, value);
+  }
+
+  public remove(variableName: string): void { this.symbols.delete(variableName); }
+
+  public getSymbols(): Map<string, NumberType> { return this.symbols }
+
+  public getParent(): SymbolTable { return this.parent }
+}

--- a/src/app/models/ast-node.ts
+++ b/src/app/models/ast-node.ts
@@ -1,8 +1,8 @@
 import { InvalidSyntaxError } from './../logic/invalid-syntax-error';
 import { Token } from './token';
-import { NumberNode } from './number-node';
 
 export interface ASTNode {
+  nodeType: string,
   token: Token,
   leftChild?: ASTNode | InvalidSyntaxError,
   rightChild?: ASTNode | InvalidSyntaxError,

--- a/src/app/models/binary-op-node.ts
+++ b/src/app/models/binary-op-node.ts
@@ -3,6 +3,7 @@ import { ASTNode } from './ast-node';
 import { Token } from './token';
 
 export interface BinaryOpNode extends ASTNode {
+  nodeType: string,
   token: Token,
   leftChild: ASTNode | InvalidSyntaxError,
   rightChild: ASTNode | InvalidSyntaxError

--- a/src/app/models/number-node.ts
+++ b/src/app/models/number-node.ts
@@ -2,5 +2,6 @@ import { ASTNode } from './ast-node';
 import { Token } from './token';
 
 export interface NumberNode extends ASTNode {
+  nodeType: string,
   token: Token
 }

--- a/src/app/models/unary-op-node.ts
+++ b/src/app/models/unary-op-node.ts
@@ -3,6 +3,7 @@ import { ASTNode } from './ast-node';
 import { Token } from './token';
 
 export interface UnaryOpNode extends ASTNode {
+  nodeType: string,
   token: Token,
   node: ASTNode | InvalidSyntaxError
 }

--- a/src/app/models/var-access-node.ts
+++ b/src/app/models/var-access-node.ts
@@ -2,5 +2,6 @@ import { ASTNode } from './ast-node';
 import { Token } from './token';
 
 export interface VarAccessNode extends ASTNode{
+  nodeType: string,
   token: Token
 }

--- a/src/app/models/var-assign-node.ts
+++ b/src/app/models/var-assign-node.ts
@@ -2,6 +2,7 @@ import { Token } from './token';
 import { ASTNode } from './ast-node';
 
 export interface VarAssignNode extends ASTNode {
+  nodeType: string,
   token: Token,
   node: ASTNode // The root node of the expression being assigned.
 }

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -254,5 +254,254 @@ describe('InterpreterService', () => {
         });
       });
     });
+
+    describe('comparison operator and logical operator tests', () => {
+      describe('comparison operator tests', () => {
+        it(`should produce a shell output of '1' for expression: 10 == 10`, () => {
+          service = new InterpreterService();
+          const source = '10 == 10';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '0' for expression: 10 > 10`, () => {
+          service = new InterpreterService();
+          const source = '10 > 10';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '1' for expression: (2 ^ 2) < ((1 + 2) * 3)`, () => {
+          service = new InterpreterService();
+          const source = '(2 ^ 2) < ((1 + 2) * 3)';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '1' for expression: (2 ^ 2) <= ((1 + 2) * 3)`, () => {
+          service = new InterpreterService();
+          const source = '(2 ^ 2) <= ((1 + 2) * 3)';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '0' for expression: 5 >= 6`, () => {
+          service = new InterpreterService();
+          const source = '5 >= 6';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '1' for expression: TRUE == TRUE`, () => {
+          service = new InterpreterService();
+          const source = 'TRUE == TRUE';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '0' for expression: TRUE == FALSE`, () => {
+          service = new InterpreterService();
+          const source = 'TRUE == FALSE';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '1' for expression: FALSE == FALSE`, () => {
+          service = new InterpreterService();
+          const source = 'FALSE == FALSE';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '1' for expression: TRUE > FALSE`, () => {
+          service = new InterpreterService();
+          const source = 'TRUE > FALSE';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '1' for expression: 10 > TRUE`, () => {
+          service = new InterpreterService();
+          const source = '10 > TRUE';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+      });
+
+      describe('logical operator tests', () => {
+        it(`should produce a shell output of '1' for expression: 1 AND 1`, () => {
+          service = new InterpreterService();
+          const source = '1 AND 1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '0' for expression: 1 AND 0`, () => {
+          service = new InterpreterService();
+          const source = '1 AND 0';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '0' for expression: 0 AND 1`, () => {
+          service = new InterpreterService();
+          const source = '0 AND 1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '0' for expression: 0 AND 0`, () => {
+          service = new InterpreterService();
+          const source = '0 AND 0';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '0' for expression: TRUE AND FALSE`, () => {
+          service = new InterpreterService();
+          const source = 'TRUE AND FALSE';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '0' for expression: 0 OR 0`, () => {
+          service = new InterpreterService();
+          const source = '0 OR 0';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '1' for expression: 1 OR 0`, () => {
+          service = new InterpreterService();
+          const source = '1 OR 0';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '1' for expression: 1 OR 1`, () => {
+          service = new InterpreterService();
+          const source = '1 OR 1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '1' for expression: TRUE OR FALSE`, () => {
+          service = new InterpreterService();
+          const source = 'TRUE OR FALSE';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '0' for expression: NOT 1`, () => {
+          service = new InterpreterService();
+          const source = 'NOT 1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '1' for expression: NOT 0`, () => {
+          service = new InterpreterService();
+          const source = 'NOT 0';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a shell output of '0' for expression: NOT TRUE`, () => {
+          service = new InterpreterService();
+          const source = 'NOT TRUE';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0');
+        });
+
+        it(`should produce a shell output of '1' for expression: NOT ((1 > 2) AND (TRUE OR FALSE))`, () => {
+          service = new InterpreterService();
+          const source = 'NOT ((1 > 2) AND (TRUE OR FALSE))';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce a console and shell output an error for expression: TRUE AND`, () => {
+          service = new InterpreterService();
+          const source = 'TRUE AND';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidSyntaxError: Expected a number, identifier, '+', '-' or ` +
+                              `'('\nAt line: 1 column: 9 and ends at line: 1 column: 10`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+      });
+    });
   });
 });

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -147,5 +147,112 @@ describe('InterpreterService', () => {
         });
       });
     });
+
+    describe('variable assignment and access tests', () => {
+      describe('variable assignment tests', () => {
+        it(`should produce shell output of '1' for expression: var = 1`, () => {
+          service = new InterpreterService();
+          const source = 'var = 1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce shell output of '-27' for expression: var = -((1 + 0.5) / (1 - 0.5)) ^ 3`, () => {
+          service = new InterpreterService();
+          const source = 'var = -((1 + 0.5) / (1 - 0.5)) ^ 3';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('-27');
+        });
+
+        it(`should produce shell output of '4' for expression: 1 + (var = 1) + 2`, () => {
+          service = new InterpreterService();
+          const source = '1 + (var = 1) + 2';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('4');
+        });
+
+        it(`should produce shell output of '4' for expression: var = 1 + (var = 1) + 2`, () => {
+          service = new InterpreterService();
+          const source = 'var = 1 + (var = 1) + 2';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('4');
+        });
+
+        it(`should produce a character error for console and shell output for expression: var =`, () => {
+          service = new InterpreterService();
+          const source = 'var =';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidCharacterError: can not end line statement with '='.\n` +
+                              `At line: 1 column: 5 and ends at line: 1 column: 6`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+
+        it(`should produce a operator syntax error for console and shell output for expression: 1 + var = 1 + 2`, () => {
+          service = new InterpreterService();
+          const source = '1 + var = 1 + 2';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidSyntaxError: Expected '+', '-', '*', '/', '^', '==', ` +
+                              `'<', '>', '<=', '>=', 'AND' or 'OR'\nAt line: 1 column: 9 and` +
+                              ` ends at line: 1 column: 10`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+      });
+
+      describe('variable access tests', () => {
+        it(`should produce shell output of '4.14159...' for expression (using the PI global pre-built variable): 1 + PI`, () => {
+          service = new InterpreterService();
+          const source = '1 + PI';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual((1 + Math.PI).toString());
+        });
+
+        it(`should produce shell output of '3.14159...' for expression (using the PI global pre-built variable): var = PI`, () => {
+          service = new InterpreterService();
+          const source = 'var = PI';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual((Math.PI).toString());
+        });
+
+        it(`should produce undefined variable runtime error for console and shell output for expression: x + 1`, () => {
+          service = new InterpreterService();
+          const source = 'x + 1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `Traceback (most recent call last):\nLine 2, in <pseudo>\n` +
+                              `Runtime Error: x is not defined\nAt line: 1 column: 1 and` +
+                              ` ends at line: 1 column: 2`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+      });
+    });
   });
 });

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -13,4 +13,139 @@ describe('InterpreterService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('evaluate tests', () => {
+    describe('arithmetic expressions', () => {
+      describe('valid expression tests', () => {
+        it(`should return empty console output with shell output '3' for expression: 1 * 2 + 4 / 2 ^ 2`, () => {
+          service = new InterpreterService();
+          const source = '1 * 2 + 4 / 2 ^ 2';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('3');
+        });
+
+        it(`should return empty console output with shell output '1' for expression: (-1) ^ 2`, () => {
+          service = new InterpreterService();
+          const source = '(-1) ^ 2';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should return empty console output with shell output '1' for expression: 5 ^ 0`, () => {
+          service = new InterpreterService();
+          const source = '5 ^ 0';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('1');
+        });
+
+        it(`should return empty console output with shell output '27' for expression: 9 ^ 1.5`, () => {
+          service = new InterpreterService();
+          const source = '9 ^ 1.5';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('27');
+        });
+
+        it(`should return empty console output with shell output '0.2' for expression: 5 ^ -1`, () => {
+          service = new InterpreterService();
+          const source = '5 ^ -1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('0.2');
+        });
+
+        it(`should return empty console output with shell output '-27' for expression: -((1 + 0.5) / (1 - 0.5)) ^ 3`, () => {
+          service = new InterpreterService();
+          const source = '-((1 + 0.5) / (1 - 0.5)) ^ 3';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('-27');
+        });
+      });
+
+      describe('erroneous expression tests', () => {
+        it(`should return character error in console output and shell output for expression: @ + 1`, () => {
+          service = new InterpreterService();
+          const source = '@ + 1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidCharacterError: the character '@' is not valid.\nAt` +
+                              ` line: 1 column: 1 and ends at line: 1 column: 2`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+
+        it(`should return character error in console output and shell output for expression: 1 + 1..50`, () => {
+          service = new InterpreterService();
+          const source = '1 + 1..50';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidCharacterError: number has more than one decimal point.\n` +
+                              `At line: 1 column: 5 and ends at line: 1 column: 6`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+
+        it(`should return missing ')' error in console output and shell output for expression: -((1 + 0.5) / (1 - 0.5) ^ 3`, () => {
+          service = new InterpreterService();
+          const source = '-((1 + 0.5) / (1 - 0.5) ^ 3';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidSyntaxError: missing ')'\nAt line: 1 column: 28 and ends` +
+                              ` at line: 1 column: 29`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+
+        it(`should return operator syntax error in console output and shell output for expression: 1 2`, () => {
+          service = new InterpreterService();
+          const source = '1 2';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidSyntaxError: Expected '+', '-', '*', '/', '^', '==', ` +
+                              `'<', '>', '<=', '>=', 'AND' or 'OR'\nAt line: 1 column: 3 and` +
+                              ` ends at line: 1 column: 4`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+
+        it(`should return runtime error in console output and shell output for expression: 10 / 0`, () => {
+          service = new InterpreterService();
+          const source = '10 / 0';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `Traceback (most recent call last):\nLine 2, in <pseudo>\n` +
+                              `Runtime Error: Division by zero\nAt line: 1 column: 6 and ends` +
+                              ` at line: 1 column: 7`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+      });
+    });
+  });
 });

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -6,6 +6,7 @@ import { Injectable } from '@angular/core';
 import { Token } from '../models/token';
 import { Lexer } from '../logic/lexer';
 import { ParseResult } from '../logic/parse-result';
+import * as NodeTypes from '../constants/node-type.constants';
 
 @Injectable({
   providedIn: 'root'
@@ -39,7 +40,7 @@ export class InterpreterService {
         consoleOutput = shellOutput = parseResult.getError().getErrorMessage();
       }
       else {
-        shellOutput = this.visitNode(parseResult.getNode());
+        shellOutput = this.visitNode(<ASTNode>parseResult.getNode());
 
         for (const output of this.outputs) {
           consoleOutput += output + "\n";
@@ -51,19 +52,32 @@ export class InterpreterService {
   }
 
   private visitNode(node: ASTNode) {
-
+    switch (node.nodeType) {
+      case NodeTypes.NUMBER:
+        return this.visitNumberNode(node);
+      case NodeTypes.BINARYOP:
+        return this.visitBinaryOpNode(node);
+      case NodeTypes.UNARYOP:
+        return this.visitUnaryOpNode(node);
+      default:
+        this.noVisitNode();
+        break;
+    }
   }
 
   private visitBinaryOpNode(node: ASTNode) {
-
+    console.log('Found binary operator node!');
+    this.visitNode(<ASTNode>node.leftChild);
+    this.visitNode(<ASTNode>node.rightChild);
   }
 
   private visitUnaryOpNode(node: ASTNode) {
-
+    console.log('Found unary operator node!');
+    this.visitNode(<ASTNode>node.node);
   }
 
   private visitNumberNode(node: ASTNode) {
-
+    console.log('Found number node!');
   }
 
   private noVisitNode(): void {

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -12,6 +12,7 @@ import { ParseResult } from '../logic/parse-result';
 })
 export class InterpreterService {
 
+  private outputs: string[];
   private lexer: Lexer;
   private parser: Parser;
 
@@ -19,21 +20,53 @@ export class InterpreterService {
     this.lexer = new Lexer();
   }
 
-  public evaluate(source: string): string {
+  public evaluate(source: string): any[] {
 
-    let output = '';
+    let consoleOutput = '';
+    let shellOutput: any;
+    this.outputs = [];
 
     let lexerOutput: Array<Token> | Error = this.lexer.lex(source);
 
     if (lexerOutput instanceof Error) {
-      output = lexerOutput.getErrorMessage();
+      consoleOutput = lexerOutput.getErrorMessage();
     }
     else {
       this.parser = new Parser(lexerOutput);
       let parseResult: ParseResult = this.parser.parse();
-      // TODO: Create visitor functionality to traverse AST and execute program.
+
+      if (parseResult.getError() !== null) {
+        consoleOutput = shellOutput = parseResult.getError().getErrorMessage();
+      }
+      else {
+        shellOutput = this.visitNode(parseResult.getNode());
+
+        for (const output of this.outputs) {
+          consoleOutput += output + "\n";
+        }
+      }
     }
 
-    return output;
+    return [consoleOutput, shellOutput];
+  }
+
+  private visitNode(node: ASTNode) {
+
+  }
+
+  private visitBinaryOpNode(node: ASTNode) {
+
+  }
+
+  private visitUnaryOpNode(node: ASTNode) {
+
+  }
+
+  private visitNumberNode(node: ASTNode) {
+
+  }
+
+  private noVisitNode(): void {
+    throw new ErrorEvent('Undefined visit method');
   }
 }

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -69,6 +69,8 @@ export class InterpreterService {
 
   private initialiseGlobalSymbolTable(): SymbolTable {
     const globalSymbolTable = new SymbolTable();
+    globalSymbolTable.set('TRUE', new NumberType(1));
+    globalSymbolTable.set('FALSE', new NumberType(0));
     globalSymbolTable.set('PI', new NumberType(Math.PI));
 
     return globalSymbolTable;
@@ -148,6 +150,25 @@ export class InterpreterService {
       case TokenTypes.POWER:
         result = left.poweredBy(right);
         break;
+      case TokenTypes.EQUALITY:
+        result = left.equalityComparison(right);
+        break;
+      case TokenTypes.L_THAN:
+        result = left.lessThanComparison(right);
+        break;
+      case TokenTypes.G_THAN:
+        result = left.greaterThanComparison(right);
+        break;
+      case TokenTypes.L_THAN_EQ:
+        result = left.lessThanOrEqualComparison(right);
+        break;
+      case TokenTypes.G_THAN_EQ:
+        result = left.greaterThanOrEqualComparison(right);
+        break;
+      case TokenTypes.KEYWORD:
+        if (node.token.value === 'AND') { result = left.andBy(right); }
+        else { result = left.orBy(right); }
+        break;
       default:
         break;
     }
@@ -168,6 +189,9 @@ export class InterpreterService {
     // TODO: May need to handle runtime errors here in the future when adding other types like
     // strings.
     if (node.token.type === TokenTypes.MINUS) { number = number.multiplyBy(new NumberType(-1)); }
+    else if (node.token.type === TokenTypes.KEYWORD && node.token.value === 'NOT') {
+      number = number.notted();
+    }
 
     return runtimeResult.success(number.setPos(node.token.positionStart, node.token.positionEnd));
   }


### PR DESCRIPTION
The interpreter evaluator is now able to traverse the abstract syntax tree made by the parser and produce relevant shell and console outputs (console outputs are all empty at the moment since the language has not got support for the planned pre-built `output` function yet). The evaluator is now able to interpret and produce outputs for arithmetic expressions, variable assignments, variable access and comparison and logical operator expressions. There is also a `RuntimeError` class for handling runtime errors which are relevant in this phase of the interpreting. There is also support for a single data type known as the `NumberType` which is used for both numbers and the underlying representation of the `TRUE` and `FALSE` keywords with values of 1 and 0 respectively. A `Context` class was also built to provide access to the symbol table which currently only works with the global scope of the source code providing pi as a pre-built global value as the keyword `PI` as well as `TRUE` and `FALSE`. It is also planned to be used to handle local scopes for when functions are implemented in the language.