### PR TITLE
feat(if-else-statements): added support for single line if-else statements

### DIFF
--- a/src/app/constants/keywords.constants.ts
+++ b/src/app/constants/keywords.constants.ts
@@ -1,1 +1,3 @@
-export const KEYWORDS = new Set(['AND', 'OR', 'NOT', 'TRUE', 'FALSE']);
+export const KEYWORDS = new Set([
+  'AND', 'OR', 'NOT', 'TRUE', 'FALSE', 'if', 'then', 'elif', 'else', 'end'
+]);

--- a/src/app/constants/node-type.constants.ts
+++ b/src/app/constants/node-type.constants.ts
@@ -3,3 +3,4 @@ export const BINARYOP = 'BinaryOpNode';
 export const UNARYOP = 'UnaryOpNode';
 export const VARACCESS = 'VarAccessNode';
 export const VARASSIGN = 'VarAssignNode';
+export const IFSTATEMENT = 'IfNode';

--- a/src/app/data-types/number-type.spec.ts
+++ b/src/app/data-types/number-type.spec.ts
@@ -543,4 +543,40 @@ describe('Number tests', () => {
       expect(newNumber.getContext()).toEqual(context);
     });
   });
+
+  describe('isTrue tests', () => {
+    it('should return true if NumberType is not 0', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(1);
+      const number2 = new NumberType(100);
+
+      number.setContext(context);
+      number2.setContext(context);
+
+      expect(number.getValue()).toEqual(1);
+      expect(number.getPosStart()).toEqual(null);
+      expect(number.getPosEnd()).toEqual(null);
+      expect(number.getContext()).toEqual(context);
+      expect(number.isTrue()).toEqual(true);
+
+      expect(number2.getValue()).toEqual(100);
+      expect(number2.getPosStart()).toEqual(null);
+      expect(number2.getPosEnd()).toEqual(null);
+      expect(number2.getContext()).toEqual(context);
+      expect(number2.isTrue()).toEqual(true);
+    });
+
+    it('should return false if NumberType is 0', () => {
+      const context = new Context('<pseudo>');
+      const number = new NumberType(0);
+
+      number.setContext(context);
+
+      expect(number.getValue()).toEqual(0);
+      expect(number.getPosStart()).toEqual(null);
+      expect(number.getPosEnd()).toEqual(null);
+      expect(number.getContext()).toEqual(context);
+      expect(number.isTrue()).toEqual(false);
+    });
+  });
 });

--- a/src/app/data-types/number-type.ts
+++ b/src/app/data-types/number-type.ts
@@ -128,6 +128,8 @@ export class NumberType {
     return new NumberType(convertedValueToBool).setContext(this.context);
   }
 
+  public isTrue(): boolean { return this.value !== 0; }
+
   public copy(): NumberType {
     const number = new NumberType(this.value);
 

--- a/src/app/logic/lexer.spec.ts
+++ b/src/app/logic/lexer.spec.ts
@@ -524,17 +524,17 @@ describe('Lexer tests', () => {
           const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(47, 6, 1));
 
           const tokenData: Array<[string, PositionTracker, any?]> = [
-            [TokenTypes.IDENTIFIER, posTracker1, 'if'], [TokenTypes.L_BRACKET, posTracker2],
+            [TokenTypes.KEYWORD, posTracker1, 'if'], [TokenTypes.L_BRACKET, posTracker2],
             [TokenTypes.NUMBER, posTracker3, 10], [TokenTypes.G_THAN, posTracker4],
             [TokenTypes.NUMBER, posTracker5, 1], [TokenTypes.KEYWORD, posTracker6, 'AND'],
             [TokenTypes.KEYWORD, posTracker7, 'TRUE'], [TokenTypes.R_BRACKET, posTracker8],
-            [TokenTypes.IDENTIFIER, posTracker9, 'then'], [TokenTypes.NEWLINE, posTracker10],
+            [TokenTypes.KEYWORD, posTracker9, 'then'], [TokenTypes.NEWLINE, posTracker10],
             [TokenTypes.IDENTIFIER, posTracker11, 'x'], [TokenTypes.EQUALS, posTracker12],
             [TokenTypes.NUMBER, posTracker13, 1], [TokenTypes.NEWLINE, posTracker14],
-            [TokenTypes.IDENTIFIER, posTracker15, 'else'], [TokenTypes.NEWLINE, posTracker16],
+            [TokenTypes.KEYWORD, posTracker15, 'else'], [TokenTypes.NEWLINE, posTracker16],
             [TokenTypes.IDENTIFIER, posTracker17, 'x'], [TokenTypes.EQUALS, posTracker18],
             [TokenTypes.NUMBER, posTracker19, 2], [TokenTypes.NEWLINE, posTracker20],
-            [TokenTypes.IDENTIFIER, posTracker21, 'end'], [TokenTypes.NEWLINE, posTracker22]
+            [TokenTypes.KEYWORD, posTracker21, 'end'], [TokenTypes.NEWLINE, posTracker22]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
@@ -587,7 +587,7 @@ describe('Lexer tests', () => {
             [TokenTypes.IDENTIFIER, posTracker15, 'x'], [TokenTypes.EQUALS, posTracker16],
             [TokenTypes.IDENTIFIER, posTracker17, 'x'], [TokenTypes.MULTIPLY, posTracker18],
             [TokenTypes.IDENTIFIER, posTracker19, 'i'], [TokenTypes.NEWLINE, posTracker20],
-            [TokenTypes.IDENTIFIER, posTracker21, 'end'], [TokenTypes.NEWLINE, posTracker22]
+            [TokenTypes.KEYWORD, posTracker21, 'end'], [TokenTypes.NEWLINE, posTracker22]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
@@ -641,7 +641,7 @@ describe('Lexer tests', () => {
             [TokenTypes.IDENTIFIER, posTracker17, 'i'], [TokenTypes.EQUALS, posTracker18],
             [TokenTypes.IDENTIFIER, posTracker19, 'i'], [TokenTypes.PLUS, posTracker20],
             [TokenTypes.NUMBER, posTracker21, 1], [TokenTypes.NEWLINE, posTracker22],
-            [TokenTypes.IDENTIFIER, posTracker23, 'end'], [TokenTypes.NEWLINE, posTracker24]
+            [TokenTypes.KEYWORD, posTracker23, 'end'], [TokenTypes.NEWLINE, posTracker24]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);
@@ -686,7 +686,7 @@ describe('Lexer tests', () => {
             [TokenTypes.IDENTIFIER, posTracker10, 'return'],
             [TokenTypes.IDENTIFIER, posTracker11, 'x'], [TokenTypes.PLUS, posTracker12],
             [TokenTypes.IDENTIFIER, posTracker13, 'y'], [TokenTypes.NEWLINE, posTracker14],
-            [TokenTypes.IDENTIFIER, posTracker15, 'end'], [TokenTypes.NEWLINE, posTracker16]
+            [TokenTypes.KEYWORD, posTracker15, 'end'], [TokenTypes.NEWLINE, posTracker16]
           ];
 
           const expected: Array<Token> = createTokenArray(tokenData);

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -1876,6 +1876,497 @@ describe('Parser tests', () => {
         expect(parseResult).toEqual(expected);
       });
     });
+
+    describe('if, elif and else statement tests', () => {
+      it('should return correct AST for statement: if 1 > 2 then 1 + 1 end', () => {
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartGThan = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(7, 1, 8);
+        const posStartThen = new PositionTracker(9, 1, 10);
+        const posStartNum3 = new PositionTracker(14, 1, 15);
+        const posStartPlus = new PositionTracker(16, 1, 17);
+        const posStartNum4 = new PositionTracker(18, 1, 19);
+        const posStartEnd = new PositionTracker(20, 1, 21);
+        const posStartEof = new PositionTracker(23, 1, 24);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.G_THAN, posStartGThan),
+          createToken(TokenTypes.NUMBER, posStartNum2, 2),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum3, 1),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.NUMBER, posStartNum4, 1),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
+        const compareNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.G_THAN, posStartGThan),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 1)
+        };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 1)
+        };
+        const addNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus),
+          leftChild: numberNode3,
+          rightChild: numberNode4
+        };
+
+        const ast: ASTNode = {
+          nodeType: NodeTypes.IFSTATEMENT,
+          token: createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          cases: [[compareNode, addNode]],
+          elseCase: null
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: if 1 > 2 then 1 + 1 elif x == y then 1 end', () => {
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartGThan = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(7, 1, 8);
+        const posStartThen = new PositionTracker(9, 1, 10);
+        const posStartNum3 = new PositionTracker(14, 1, 15);
+        const posStartPlus = new PositionTracker(16, 1, 17);
+        const posStartNum4 = new PositionTracker(18, 1, 19);
+        const posStartElif = new PositionTracker(20, 1, 21);
+        const posStartVarX = new PositionTracker(25, 1, 26);
+        const posStartEquality = new PositionTracker(27, 1, 28);
+        const posStartVarY = new PositionTracker(30, 1, 31);
+        const posStartThen2 = new PositionTracker(32, 1, 33);
+        const posStartNum5 = new PositionTracker(37, 1, 38);
+        const posStartEnd = new PositionTracker(39, 1, 40);
+        const posStartEof = new PositionTracker(42, 1, 43);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.G_THAN, posStartGThan),
+          createToken(TokenTypes.NUMBER, posStartNum2, 2),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum3, 1),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.NUMBER, posStartNum4, 1),
+          createToken(TokenTypes.KEYWORD, posStartElif, 'elif'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALITY, posStartEquality),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartThen2, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum5, 1),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
+        const greaterThanNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.G_THAN, posStartGThan),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 1)
+        };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 1)
+        };
+        const addNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus),
+          leftChild: numberNode3,
+          rightChild: numberNode4
+        };
+
+        const varAccessNode1: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x')
+        };
+        const varAccessNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y')
+        };
+        const equalityNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.EQUALITY, posStartEquality),
+          leftChild: varAccessNode1,
+          rightChild: varAccessNode2
+        };
+
+        const numberNode5: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum5, 1)
+        };
+        const ast: ASTNode = {
+          nodeType: NodeTypes.IFSTATEMENT,
+          token: createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          cases: [[greaterThanNode, addNode], [equalityNode, numberNode5]],
+          elseCase: null
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 15; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement with many elifs and an else at the end', () => {
+        // Expression: if 1 > 2 then 1 + 1 elif x == y then 1 elif 1 < 2 then 2 elif x >= y then 0 else 1 + 1 end
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartGThan = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(7, 1, 8);
+        const posStartThen = new PositionTracker(9, 1, 10);
+        const posStartNum3 = new PositionTracker(14, 1, 15);
+        const posStartPlus = new PositionTracker(16, 1, 17);
+        const posStartNum4 = new PositionTracker(18, 1, 19);
+        const posStartElif = new PositionTracker(20, 1, 21);
+        const posStartVarX = new PositionTracker(25, 1, 26);
+        const posStartEquality = new PositionTracker(27, 1, 28);
+        const posStartVarY = new PositionTracker(30, 1, 31);
+        const posStartThen2 = new PositionTracker(32, 1, 33);
+        const posStartNum5 = new PositionTracker(37, 1, 38);
+        const posStartElif2 = new PositionTracker(39, 1, 40);
+        const posStartNum6 = new PositionTracker(44, 1, 45);
+        const posStartLThan = new PositionTracker(46, 1, 47);
+        const posStartNum7 = new PositionTracker(48, 1, 49);
+        const posStartThen3 = new PositionTracker(50, 1, 51);
+        const posStartNum8 = new PositionTracker(55, 1, 56);
+        const posStartElif3 = new PositionTracker(57, 1, 58);
+        const posStartVarX2 = new PositionTracker(62, 1, 63);
+        const posStartGThanEqual = new PositionTracker(64, 1, 65);
+        const posStartVarY2 = new PositionTracker(67, 1, 68);
+        const posStartThen4 = new PositionTracker(69, 1, 70);
+        const posStartNum9 = new PositionTracker(74, 1, 75);
+        const posStartElse = new PositionTracker(76, 1, 77);
+        const posStartNum10 = new PositionTracker(81, 1, 82);
+        const posStartPlus2 = new PositionTracker(83, 1, 84);
+        const posStartNum11 = new PositionTracker(85, 1, 86);
+        const posStartEnd = new PositionTracker(87, 1, 88);
+        const posStartEof = new PositionTracker(90, 1, 91);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.G_THAN, posStartGThan),
+          createToken(TokenTypes.NUMBER, posStartNum2, 2),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum3, 1),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.NUMBER, posStartNum4, 1),
+          createToken(TokenTypes.KEYWORD, posStartElif, 'elif'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALITY, posStartEquality),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartThen2, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum5, 1),
+          createToken(TokenTypes.KEYWORD, posStartElif2, 'elif'),
+          createToken(TokenTypes.NUMBER, posStartNum6, 1),
+          createToken(TokenTypes.L_THAN, posStartLThan),
+          createToken(TokenTypes.NUMBER, posStartNum7, 2),
+          createToken(TokenTypes.KEYWORD, posStartThen3, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum8, 2),
+          createToken(TokenTypes.KEYWORD, posStartElif3, 'elif'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.G_THAN_EQ, posStartGThanEqual),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartThen4, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum9, 0),
+          createToken(TokenTypes.KEYWORD, posStartElse, 'else'),
+          createToken(TokenTypes.NUMBER, posStartNum10, 1),
+          createToken(TokenTypes.PLUS, posStartPlus2),
+          createToken(TokenTypes.NUMBER, posStartNum11, 1),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
+        const greaterThanNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.G_THAN, posStartGThan),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 1)
+        };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 1)
+        };
+        const addNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus),
+          leftChild: numberNode3,
+          rightChild: numberNode4
+        };
+
+        const varAccessNode1: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x')
+        };
+        const varAccessNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y')
+        };
+        const equalityNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.EQUALITY, posStartEquality),
+          leftChild: varAccessNode1,
+          rightChild: varAccessNode2
+        };
+
+        const numberNode5: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum5, 1)
+        };
+
+        const numberNode6: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum6, 1)
+        };
+        const numberNode7: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum7, 2)
+        };
+        const lessThanNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.L_THAN, posStartLThan),
+          leftChild: numberNode6,
+          rightChild: numberNode7
+        };
+
+        const numberNode8: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum8, 2)
+        };
+
+        const varAccessNode3: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x')
+        };
+        const varAccessNode4: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y')
+        };
+        const gThanEqualNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.G_THAN_EQ, posStartGThanEqual),
+          leftChild: varAccessNode3,
+          rightChild: varAccessNode4
+        };
+
+        const numberNode9: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum9, 0)
+        };
+
+        const numberNode10: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum10, 1)
+        };
+        const numberNode11: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum11, 1)
+        };
+        const addNode2: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus2),
+          leftChild: numberNode10,
+          rightChild: numberNode11
+        };
+
+        const ast: ASTNode = {
+          nodeType: NodeTypes.IFSTATEMENT,
+          token: createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          cases: [[greaterThanNode, addNode], [equalityNode, numberNode5],
+                  [lessThanNode, numberNode8], [gThanEqualNode, numberNode9]],
+          elseCase: addNode2
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 31; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing 'then' in parse result for expression: if 1 == 1 1 end`, () => {
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartEquality = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(8, 1, 9);
+        const posStartNum3 = new PositionTracker(10, 1, 11);
+        const posEndNum3 = new PositionTracker(11, 1, 12);
+        const posStartEnd = new PositionTracker(12, 1, 13);
+        const posStartEof = new PositionTracker(15, 1, 16);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.EQUALITY, posStartEquality),
+          createToken(TokenTypes.NUMBER, posStartNum2, 1),
+          createToken(TokenTypes.NUMBER, posStartNum3, 1),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected 'then' keyword`, posStartNum3,
+                                              posEndNum3);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing 'then' in parse result for expression: if 1 == 1 then 1 elif 1 > 0 1 + 1 end`, () => {
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartEquality = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(8, 1, 9);
+        const posStartThen = new PositionTracker(10, 1, 11);
+        const posStartNum3 = new PositionTracker(15, 1, 16);
+        const posStartElif = new PositionTracker(17, 1, 18);
+        const posStartNum4 = new PositionTracker(22, 1, 23);
+        const posStartGThan = new PositionTracker(24, 1, 25);
+        const posStartNum5 = new PositionTracker(26, 1, 27);
+        const posStartNum6 = new PositionTracker(28, 1, 29);
+        const posEndNum6 = new PositionTracker(29, 1, 30);
+        const posStartPlus = new PositionTracker(30, 1, 31);
+        const posStartNum7 = new PositionTracker(32, 1, 33);
+        const posStartEnd = new PositionTracker(34, 1, 35);
+        const posStartEof = new PositionTracker(37, 1, 38);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.EQUALITY, posStartEquality),
+          createToken(TokenTypes.NUMBER, posStartNum2, 1),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum3, 1),
+          createToken(TokenTypes.KEYWORD, posStartElif, 'elif'),
+          createToken(TokenTypes.NUMBER, posStartNum4, 1),
+          createToken(TokenTypes.G_THAN, posStartGThan),
+          createToken(TokenTypes.NUMBER, posStartNum5, 0),
+          createToken(TokenTypes.NUMBER, posStartNum6, 1),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.NUMBER, posStartNum7, 1),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected 'then' keyword`, posStartNum6,
+                                              posEndNum6);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 10; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing 'end' in parse result for expression: if 1 == 1 then 1`, () => {
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartEquality = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(8, 1, 9);
+        const posStartThen = new PositionTracker(10, 1, 11);
+        const posStartNum3 = new PositionTracker(15, 1, 16);
+        const posStartEof = new PositionTracker(16, 1, 17);
+        const posEndEof = new PositionTracker(17, 1, 18);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.EQUALITY, posStartEquality),
+          createToken(TokenTypes.NUMBER, posStartNum2, 1),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NUMBER, posStartNum3, 1),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected 'end' keyword`, posStartEof,
+                                              posEndEof);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+    });
   });
 });
 

--- a/src/app/models/ast-node.ts
+++ b/src/app/models/ast-node.ts
@@ -7,4 +7,6 @@ export interface ASTNode {
   leftChild?: ASTNode | InvalidSyntaxError,
   rightChild?: ASTNode | InvalidSyntaxError,
   node?: ASTNode | InvalidSyntaxError // Some nodes have single nodes such as NumberNode.
+  cases?: Array<[ASTNode, ASTNode]>,
+  elseCase?: ASTNode
 }

--- a/src/app/models/if-node.ts
+++ b/src/app/models/if-node.ts
@@ -1,0 +1,9 @@
+import { Token } from './token';
+import { ASTNode } from './ast-node';
+
+export interface IfNode extends ASTNode {
+  nodeType: string,
+  token: Token,
+  cases: Array<[ASTNode, ASTNode]>,
+  elseCase: ASTNode
+}

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -503,5 +503,86 @@ describe('InterpreterService', () => {
         });
       });
     });
+
+    describe('if, elif and else statement tests', () => {
+      it(`should produce a shell output of '2' for expression: if PI > 3 then 1 + 1 end`, () => {
+        service = new InterpreterService();
+        const source = 'if PI > 3 then 1 + 1 end';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('');
+        expect(shellOut).toEqual('2');
+      });
+
+      it(`should produce a shell output of '100' for expression: if PI == 3 then 1 + 1 else 100 end`, () => {
+        service = new InterpreterService();
+        const source = 'if PI == 3 then 1 + 1 else 100 end';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('');
+        expect(shellOut).toEqual('100');
+      });
+
+      it(`should produce a shell output of '1' for expression: if FALSE then 5 elif TRUE then 1 else 100 end`, () => {
+        service = new InterpreterService();
+        const source = 'if FALSE then 5 elif TRUE then 1 else 100 end';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('');
+        expect(shellOut).toEqual('1');
+      });
+
+      it(`should produce a shell output of '0' for expression: if FALSE then 5 elif FALSE then 1 elif TRUE then 0 else 100 end`, () => {
+        service = new InterpreterService();
+        const source = 'if FALSE then 5 elif FALSE then 1 elif TRUE then 0 else 100 end';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('');
+        expect(shellOut).toEqual('0');
+      });
+
+      it(`should produce a console/shell syntax error missing 'then' keyword for expression: if TRUE 5 end`, () => {
+        service = new InterpreterService();
+        const source = 'if TRUE 5 end';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        const expectedErr = `InvalidSyntaxError: Expected 'then' keyword\nAt line: 1 column:` +
+                            ` 9 and ends at line: 1 column: 10`;
+
+        expect(consoleOut).toEqual(expectedErr);
+        expect(shellOut).toEqual(expectedErr);
+      });
+
+      it(`should produce a console/shell syntax error missing 'end' keyword for expression: if TRUE then 5`, () => {
+        service = new InterpreterService();
+        const source = 'if TRUE then 5';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        const expectedErr = `InvalidSyntaxError: Expected 'end' keyword\nAt line: 1 column:` +
+                            ` 15 and ends at line: 1 column: 16`;
+
+        expect(consoleOut).toEqual(expectedErr);
+        expect(shellOut).toEqual(expectedErr);
+      });
+
+      it(`should produce a console/shell syntax error missing 'then' keyword for expression: if FALSE then 5 elif TRUE 1 end`, () => {
+        service = new InterpreterService();
+        const source = 'if FALSE then 5 elif TRUE 1 end';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        const expectedErr = `InvalidSyntaxError: Expected 'then' keyword\nAt line: 1 column:` +
+                            ` 27 and ends at line: 1 column: 28`;
+
+        expect(consoleOut).toEqual(expectedErr);
+        expect(shellOut).toEqual(expectedErr);
+      });
+    });
   });
 });


### PR DESCRIPTION
The language now supports single-line if/elif/else statements. They follow the following syntax:

- if [condition-expression] then [expression] end
- if [condition-expression] then [expression] elif [condition-expression] then [expression] end (can have any number of elifs.)
- if [condition-expression] then [expression] else [expression] end
- if [condition-expression] then [expression] elif [condition-expression] then [expression] else [expression] end (can have any number of elifs.)

There is also runtime error messages produced for missing keywords in the expression such as 'then' or 'end' in the appropriate places.