### PR TITLE
feat(functions): added support for function definition/calls

### DIFF
--- a/src/app/constants/keywords.constants.ts
+++ b/src/app/constants/keywords.constants.ts
@@ -1,4 +1,4 @@
 export const KEYWORDS = new Set([
   'AND', 'OR', 'NOT', 'TRUE', 'FALSE', 'if', 'then', 'elif', 'else', 'end', 'for', 'to', 'step',
-  'loop', 'while'
+  'loop', 'while', 'function', 'begin'
 ]);

--- a/src/app/constants/node-type.constants.ts
+++ b/src/app/constants/node-type.constants.ts
@@ -6,3 +6,5 @@ export const VARASSIGN = 'VarAssignNode';
 export const IFSTATEMENT = 'IfNode';
 export const FORLOOP = 'ForNode';
 export const WHILELOOP = 'WhileNode';
+export const FUNCTIONDEF = 'FunctionDefNode';
+export const FUNCTIONCALL = 'FunctionCallNode';

--- a/src/app/data-types/function-type.spec.ts
+++ b/src/app/data-types/function-type.spec.ts
@@ -1,0 +1,160 @@
+import { RuntimeResult } from './../logic/runtime-result';
+import { Context } from './../logic/context';
+import { NumberType } from './number-type';
+import { PositionTracker } from './../logic/position-tracker';
+import { ASTNode } from './../models/ast-node';
+import { FunctionType } from './function-type';
+import * as NodeTypes from '../constants/node-type.constants';
+import * as TokenTypes from '../constants/token-type.constants';
+import {createToken} from '../utils/token-functions';
+import { SymbolTable } from '../logic/symbol-table';
+
+describe('FunctionType tests', () => {
+  describe('execute tests', () => {
+    it('should return correct value when calling function with correct arguments', () => {
+      const posStartFunction = new PositionTracker(0, 1, 1);
+      const posEndFunction = new PositionTracker(1, 1, 2);
+      const posStartX = new PositionTracker(25, 1, 26);
+      const posStartPlus = new PositionTracker(27, 1, 28);
+      const posStartY = new PositionTracker(29, 1, 30);
+
+      const number1 = new NumberType(1);
+      const number2 = new NumberType(2);
+      const functionContext = new Context('add');
+      functionContext.symbolTable = new SymbolTable();
+
+      const varX: ASTNode = {
+        nodeType: NodeTypes.VARACCESS,
+        token: createToken(TokenTypes.IDENTIFIER, posStartX, 'x')
+      };
+      const varY: ASTNode = {
+        nodeType: NodeTypes.VARACCESS,
+        token: createToken(TokenTypes.IDENTIFIER, posStartY, 'y')
+      };
+      const addNode: ASTNode = {
+        nodeType: NodeTypes.BINARYOP,
+        token: createToken(TokenTypes.PLUS, posStartPlus),
+        leftChild: varX,
+        rightChild: varY
+      };
+      const args: string[] = ['x', 'y'];
+
+      const functionType = new FunctionType(addNode, args, 'add');
+
+      // Create function scope.
+      functionType.setPos(posStartFunction, posEndFunction);
+      functionType.setContext(functionContext);
+      functionType.getContext().symbolTable.set('x', number1);
+      functionType.getContext().symbolTable.set('y', number2);
+
+      const value: NumberType = <NumberType>functionType.execute([number1, number2]).getValue();
+      expect(value.getValue()).toEqual(3);
+    });
+
+    it('should return runtime result error for to few arguments', () => {
+      const posStartFunction = new PositionTracker(0, 1, 1);
+      const posEndFunction = new PositionTracker(1, 1, 2);
+      const posStartX = new PositionTracker(25, 1, 26);
+      const posStartPlus = new PositionTracker(27, 1, 28);
+      const posStartY = new PositionTracker(29, 1, 30);
+
+      const number1 = new NumberType(1);
+      const number2 = new NumberType(2);
+      const functionContext = new Context('add');
+      functionContext.symbolTable = new SymbolTable();
+
+      const varX: ASTNode = {
+        nodeType: NodeTypes.VARACCESS,
+        token: createToken(TokenTypes.IDENTIFIER, posStartX, 'x')
+      };
+      const varY: ASTNode = {
+        nodeType: NodeTypes.VARACCESS,
+        token: createToken(TokenTypes.IDENTIFIER, posStartY, 'y')
+      };
+      const addNode: ASTNode = {
+        nodeType: NodeTypes.BINARYOP,
+        token: createToken(TokenTypes.PLUS, posStartPlus),
+        leftChild: varX,
+        rightChild: varY
+      };
+      const args: string[] = ['x', 'y'];
+
+      const functionType = new FunctionType(addNode, args, 'add');
+
+      // Create function scope.
+      functionType.setPos(posStartFunction, posEndFunction);
+      functionType.setContext(functionContext);
+      functionType.getContext().symbolTable.set('x', number1);
+      functionType.getContext().symbolTable.set('y', number2);
+
+      const result: RuntimeResult = functionType.execute([number1]);
+
+      const expectedErrorMessage = `Traceback (most recent call last):\nLine 2, in add\nRuntime` +
+                                   ` Error: 1 arguments were passed into add. Expected 2\n` +
+                                   `At line: 1 column: 1 and ends at line: 1 column: 2`;
+
+      expect(result.getError().getErrorMessage()).toEqual(expectedErrorMessage);
+    });
+
+    it('should return runtime result error for to many arguments', () => {
+      const posStartFunction = new PositionTracker(0, 1, 1);
+      const posEndFunction = new PositionTracker(1, 1, 2);
+      const posStartX = new PositionTracker(25, 1, 26);
+      const posStartPlus = new PositionTracker(27, 1, 28);
+      const posStartY = new PositionTracker(29, 1, 30);
+
+      const number1 = new NumberType(1);
+      const number2 = new NumberType(2);
+      const number3 = new NumberType(2);
+      const functionContext = new Context('add');
+      functionContext.symbolTable = new SymbolTable();
+
+      const varX: ASTNode = {
+        nodeType: NodeTypes.VARACCESS,
+        token: createToken(TokenTypes.IDENTIFIER, posStartX, 'x')
+      };
+      const varY: ASTNode = {
+        nodeType: NodeTypes.VARACCESS,
+        token: createToken(TokenTypes.IDENTIFIER, posStartY, 'y')
+      };
+      const addNode: ASTNode = {
+        nodeType: NodeTypes.BINARYOP,
+        token: createToken(TokenTypes.PLUS, posStartPlus),
+        leftChild: varX,
+        rightChild: varY
+      };
+      const args: string[] = ['x', 'y'];
+
+      const functionType = new FunctionType(addNode, args, 'add');
+
+      // Create function scope.
+      functionType.setPos(posStartFunction, posEndFunction);
+      functionType.setContext(functionContext);
+      functionType.getContext().symbolTable.set('x', number1);
+      functionType.getContext().symbolTable.set('y', number2);
+
+      const result: RuntimeResult = functionType.execute([number1, number2, number3]);
+
+      const expectedErrorMessage = `Traceback (most recent call last):\nLine 2, in add\nRuntime` +
+                                   ` Error: 3 arguments were passed into add. Expected 2\n` +
+                                   `At line: 1 column: 1 and ends at line: 1 column: 2`;
+
+      expect(result.getError().getErrorMessage()).toEqual(expectedErrorMessage);
+    });
+  });
+
+  describe('copy tests', () => {
+    it('should return a new copied instance of the FunctionType when calling copy', () => {
+      const posStartNum = new PositionTracker(10, 1, 11);
+      const number: ASTNode = {
+        nodeType: NodeTypes.NUMBER,
+        token: createToken(TokenTypes.NUMBER, posStartNum, 1),
+      };
+      const functionType = new FunctionType(number, [], 'func');
+
+      const copiedFunctionType: FunctionType = functionType.copy();
+
+      expect(functionType).toEqual(copiedFunctionType);
+    });
+  });
+});

--- a/src/app/data-types/function-type.ts
+++ b/src/app/data-types/function-type.ts
@@ -46,6 +46,8 @@ export class FunctionType extends ValueType {
     return copy;
   }
 
+  public getName(): string { return this.name; }
+
   private checkArgLengths(args: ValueType[]): RuntimeResult {
     const runtimeResult = new RuntimeResult();
 

--- a/src/app/data-types/function-type.ts
+++ b/src/app/data-types/function-type.ts
@@ -1,0 +1,61 @@
+import { RuntimeError } from './../logic/runtime-error';
+import { SymbolTable } from './../logic/symbol-table';
+import { Context } from './../logic/context';
+import { InterpreterService } from './../services/interpreter.service';
+import { RuntimeResult } from './../logic/runtime-result';
+import { ASTNode } from './../models/ast-node';
+import { ValueType } from './value-type';
+
+export class FunctionType extends ValueType {
+  private name: string;
+
+  constructor(private bodyNode: ASTNode, private argNames: string[], name?: string) {
+    super();
+    this.name = name === undefined ? '<anonymous>' : name;
+  }
+
+  public execute(args: ValueType[]): RuntimeResult {
+    let runtimeResult = new RuntimeResult();
+    const interpreter = new InterpreterService();
+    let newContext = new Context(this.name, this.context, this.posStart);
+
+    newContext.symbolTable = new SymbolTable(newContext.getParent().symbolTable);
+
+    runtimeResult = this.checkArgLengths(args);
+    if (runtimeResult.getError() !== null) { return runtimeResult; }
+
+    for (let i = 0; i < args.length; i++) {
+      const argName: string = this.argNames[i];
+      const argValue: ValueType = args[i];
+
+      argValue.setContext(newContext); // Set the scope of the argument within the function.
+      newContext.symbolTable.set(argName, argValue);
+    }
+
+    const value: ValueType = runtimeResult.register(interpreter.visitNode(this.bodyNode, newContext));
+    if (runtimeResult.getError() !== null) { return runtimeResult; }
+
+    return runtimeResult.success(value);
+  }
+
+  public copy(): FunctionType {
+    const copy = new FunctionType(this.bodyNode, this.argNames, this.name);
+    copy.setPos(this.posStart, this.posEnd);
+    copy.setContext(this.context);
+
+    return copy;
+  }
+
+  private checkArgLengths(args: ValueType[]): RuntimeResult {
+    const runtimeResult = new RuntimeResult();
+
+    if (args.length !== this.argNames.length) {
+      const runtimeError = new RuntimeError(`${args.length} arguments were passed into ` +
+                                            `${this.name}. Expected ${this.argNames.length}`,
+                                            this.posStart, this.posEnd, this.context);
+      return runtimeResult.failure(runtimeError);
+    }
+
+    return runtimeResult;
+  }
+}

--- a/src/app/data-types/number-type.spec.ts
+++ b/src/app/data-types/number-type.spec.ts
@@ -2,6 +2,7 @@ import { RuntimeError } from './../logic/runtime-error';
 import { PositionTracker } from './../logic/position-tracker';
 import { NumberType } from './number-type';
 import { Context } from '../logic/context';
+import { ValueType } from './value-type';
 
 describe('Number tests', () => {
   it('should initialise with with passed value but with null position tracker and context', () => {
@@ -65,12 +66,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(5);
 
       number.setContext(context);
-      const newNumber: NumberType = number.addBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.addBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(15);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(15); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -81,12 +85,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(5);
 
       number.setContext(context);
-      const newNumber: NumberType = number.subtractBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.subtractBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(5);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(5); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -97,12 +104,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(5);
 
       number.setContext(context);
-      const newNumber: NumberType = number.multiplyBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.multiplyBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(50);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(50); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -113,12 +123,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(5);
 
       number.setContext(context);
-      const [newNumber, _]: [NumberType, RuntimeError] = number.divideBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.divideBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(2);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(2); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return runtime error when passing a NumberType with value 0', () => {
@@ -130,7 +143,7 @@ describe('Number tests', () => {
                                                                       otherNumber.getContext());
 
       number.setContext(context);
-      const [newNumber, error]: [NumberType, RuntimeError] = number.divideBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.divideBy(otherNumber);
 
       expect(newNumber).toEqual(null);
       expect(error).toEqual(expectedRuntimeErr);
@@ -144,12 +157,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(5);
 
       number.setContext(context);
-      const newNumber: NumberType = number.poweredBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.poweredBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(100000);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(100000); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -160,12 +176,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(10);
 
       number.setContext(context);
-      const newNumber: NumberType = number.equalityComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.equalityComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when values are not equal', () => {
@@ -174,12 +193,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(11);
 
       number.setContext(context);
-      const newNumber: NumberType = number.equalityComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.equalityComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -190,12 +212,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(2);
 
       number.setContext(context);
-      const newNumber: NumberType = number.lessThanComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.lessThanComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when number is equal to otherNumber', () => {
@@ -204,12 +229,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.lessThanComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.lessThanComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when number is greater than otherNumber', () => {
@@ -218,12 +246,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.lessThanComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.lessThanComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -234,12 +265,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.greaterThanComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.greaterThanComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when number is equal to otherNumber', () => {
@@ -248,12 +282,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.greaterThanComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.greaterThanComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when number is less than otherNumber', () => {
@@ -262,12 +299,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(2);
 
       number.setContext(context);
-      const newNumber: NumberType = number.greaterThanComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.greaterThanComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -278,12 +318,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(2);
 
       number.setContext(context);
-      const newNumber: NumberType = number.lessThanOrEqualComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.lessThanOrEqualComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 1 when number is equal to otherNumber', () => {
@@ -292,12 +335,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.lessThanOrEqualComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.lessThanOrEqualComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when number is greater than otherNumber', () => {
@@ -306,12 +352,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.lessThanOrEqualComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.lessThanOrEqualComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -322,12 +371,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.greaterThanOrEqualComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.greaterThanOrEqualComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 1 when number is equal to otherNumber', () => {
@@ -336,12 +388,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.greaterThanOrEqualComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.greaterThanOrEqualComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when number is less than otherNumber', () => {
@@ -350,12 +405,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(2);
 
       number.setContext(context);
-      const newNumber: NumberType = number.greaterThanOrEqualComparison(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.greaterThanOrEqualComparison(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -366,12 +424,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(0);
 
       number.setContext(context);
-      const newNumber: NumberType = number.andBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.andBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when number is 1 and otherNumber is 0', () => {
@@ -380,12 +441,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(0);
 
       number.setContext(context);
-      const newNumber: NumberType = number.andBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.andBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 0 when number is 0 and otherNumber is 1', () => {
@@ -394,12 +458,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.andBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.andBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 1 when number is 1 and otherNumber is 1', () => {
@@ -408,12 +475,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.andBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.andBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 1 when number is 100 and otherNumber is 10 (treated as 1s)', () => {
@@ -422,12 +492,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(10);
 
       number.setContext(context);
-      const newNumber: NumberType = number.andBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.andBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -438,12 +511,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(0);
 
       number.setContext(context);
-      const newNumber: NumberType = number.orBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.orBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 1 when number is 1 and otherNumber is 0', () => {
@@ -452,12 +528,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(0);
 
       number.setContext(context);
-      const newNumber: NumberType = number.orBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.orBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 1 when number is 0 and otherNumber is 1', () => {
@@ -466,12 +545,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.orBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.orBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 1 when number is 1 and otherNumber is 1', () => {
@@ -480,12 +562,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.orBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.orBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with a value of 1 when number is 100 and otherNumber is 10 (treated as 1s)', () => {
@@ -494,12 +579,15 @@ describe('Number tests', () => {
       const otherNumber = new NumberType(10);
 
       number.setContext(context);
-      const newNumber: NumberType = number.orBy(otherNumber);
+      const [newNumber, error]: [ValueType, RuntimeError] = number.orBy(otherNumber);
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 
@@ -509,12 +597,15 @@ describe('Number tests', () => {
       const number = new NumberType(1);
 
       number.setContext(context);
-      const newNumber: NumberType = number.notted();
+      const [newNumber, error]: [ValueType, RuntimeError] = number.notted();
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with value of 1 when number is 0', () => {
@@ -522,12 +613,15 @@ describe('Number tests', () => {
       const number = new NumberType(0);
 
       number.setContext(context);
-      const newNumber: NumberType = number.notted();
+      const [newNumber, error]: [ValueType, RuntimeError] = number.notted();
 
-      expect(newNumber.getValue()).toEqual(1);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(1); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
 
     it('should return NumberType with value of 0 when number is 100 (treated as 1)', () => {
@@ -535,12 +629,15 @@ describe('Number tests', () => {
       const number = new NumberType(100);
 
       number.setContext(context);
-      const newNumber: NumberType = number.notted();
+      const [newNumber, error]: [ValueType, RuntimeError] = number.notted();
 
-      expect(newNumber.getValue()).toEqual(0);
+      if (newNumber instanceof NumberType) { expect(newNumber.getValue()).toEqual(0); }
+      else { fail('newNumber is not an instance of NumberType'); }
+
       expect(newNumber.getPosStart()).toEqual(null);
       expect(newNumber.getPosEnd()).toEqual(null);
       expect(newNumber.getContext()).toEqual(context);
+      expect(error).toEqual(null);
     });
   });
 

--- a/src/app/data-types/number-type.ts
+++ b/src/app/data-types/number-type.ts
@@ -1,52 +1,39 @@
 import { Context } from './../logic/context';
 import { RuntimeError } from './../logic/runtime-error';
 import { PositionTracker } from './../logic/position-tracker';
+import { ValueType } from './value-type';
 
 /**
  * Used to represent both numbers and boolean primitives in Pseudo.
  */
-export class NumberType {
-
-  private posStart: PositionTracker;
-  private posEnd: PositionTracker;
-  private context;
+export class NumberType extends ValueType {
 
   constructor(private value: number) {
-    this.setPos(null, null);
-    this.setContext(null);
+    super();
   }
 
-  public setPos(start: PositionTracker, end: PositionTracker): NumberType {
-    this.posStart = start;
-    this.posEnd = end;
-
-    return this;
-  }
-
-  public setContext(context: Context): NumberType {
-    this.context = context;
-    return this;
-  }
-
-  public addBy(other: NumberType): NumberType {
+  public addBy(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
-      return new NumberType(this.value + other.getValue()).setContext(this.context);
+      return [new NumberType(this.value + other.getValue()).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public subtractBy(other: NumberType): NumberType {
+  public subtractBy(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
-      return new NumberType(this.value - other.getValue()).setContext(this.context);
+      return [new NumberType(this.value - other.getValue()).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public multiplyBy(other: NumberType): NumberType {
+  public multiplyBy(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
-      return new NumberType(this.value * other.getValue()).setContext(this.context);
+      return [new NumberType(this.value * other.getValue()).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public divideBy(other: NumberType): [NumberType, RuntimeError] {
+  public divideBy(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
       if (other.getValue() === 0) {
         return [null, new RuntimeError('Division by zero', other.getPosStart(),
@@ -55,77 +42,86 @@ export class NumberType {
 
       return [new NumberType(this.value / other.getValue()).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public poweredBy(other: NumberType): NumberType {
+  public poweredBy(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
-      return new NumberType(this.value ** other.getValue()).setContext(this.context);
+      return [new NumberType(this.value ** other.getValue()).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public equalityComparison(other: NumberType): NumberType {
+  public equalityComparison(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
       // This expression is most performant way to convert from boolean to number in Javascript.
       const convertedBoolToNum: number = this.value === other.getValue() ? 1 : 0;
-      return new NumberType(convertedBoolToNum).setContext(this.context);
+      return [new NumberType(convertedBoolToNum).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public lessThanComparison(other: NumberType): NumberType {
+  public lessThanComparison(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
       // This expression is most performant way to convert from boolean to number in Javascript.
       const convertedBoolToNum: number = this.value < other.getValue() ? 1 : 0;
-      return new NumberType(convertedBoolToNum).setContext(this.context);
+      return [new NumberType(convertedBoolToNum).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public greaterThanComparison(other: NumberType): NumberType {
+  public greaterThanComparison(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
       // This expression is most performant way to convert from boolean to number in Javascript.
       const convertedBoolToNum: number = this.value > other.getValue() ? 1 : 0;
-      return new NumberType(convertedBoolToNum).setContext(this.context);
+      return [new NumberType(convertedBoolToNum).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public lessThanOrEqualComparison(other: NumberType): NumberType {
+  public lessThanOrEqualComparison(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
       // This expression is most performant way to convert from boolean to number in Javascript.
       const convertedBoolToNum: number = this.value <= other.getValue() ? 1 : 0;
-      return new NumberType(convertedBoolToNum).setContext(this.context);
+      return [new NumberType(convertedBoolToNum).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public greaterThanOrEqualComparison(other: NumberType): NumberType {
+  public greaterThanOrEqualComparison(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
       // This expression is most performant way to convert from boolean to number in Javascript.
       const convertedBoolToNum: number = this.value >= other.getValue() ? 1 : 0;
-      return new NumberType(convertedBoolToNum).setContext(this.context);
+      return [new NumberType(convertedBoolToNum).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public andBy(other: NumberType): NumberType {
+  public andBy(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
       // This expression is most performant way to convert from boolean to number in Javascript.
       const convertedValue: number = this.value !== 0 ? 1 : 0;
       const convertedOther: number = other.getValue() !== 0 ? 1 : 0;
       const convertedBoolToNum: number = convertedValue && convertedOther;
-      return new NumberType(convertedBoolToNum).setContext(this.context);
+      return [new NumberType(convertedBoolToNum).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public orBy(other: NumberType): NumberType {
+  public orBy(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
       // This expression is most performant way to convert from boolean to number in Javascript.
       const convertedValue: number = this.value !== 0 ? 1 : 0;
       const convertedOther: number = other.getValue() !== 0 ? 1 : 0;
       const convertedBoolToNum: number = convertedValue || convertedOther;
-      return new NumberType(convertedBoolToNum).setContext(this.context);
+      return [new NumberType(convertedBoolToNum).setContext(this.context), null];
     }
+    else { return [null, this.illegalOperation()]; }
   }
 
-  public notted(): NumberType {
+  public notted(): [ValueType, RuntimeError] {
     const convertedValueToBool: number = this.value === 0 ? 1 : 0;
-    return new NumberType(convertedValueToBool).setContext(this.context);
+    return [new NumberType(convertedValueToBool).setContext(this.context), null];
   }
 
   public isTrue(): boolean { return this.value !== 0; }
@@ -140,10 +136,4 @@ export class NumberType {
   }
 
   public getValue(): number { return this.value; }
-
-  public getPosStart(): PositionTracker { return this.posStart; }
-
-  public getPosEnd(): PositionTracker { return this.posEnd; }
-
-  public getContext(): Context { return this.context; }
 }

--- a/src/app/data-types/value-type.spec.ts
+++ b/src/app/data-types/value-type.spec.ts
@@ -1,0 +1,292 @@
+import { ValueType } from "./value-type";
+import { PositionTracker } from '../logic/position-tracker';
+import { Context } from '../logic/context';
+import { RuntimeError } from '../logic/runtime-error';
+import { RuntimeResult } from '../logic/runtime-result';
+
+describe('ValueType tests', () => {
+  it('should initialise ValueType with posStart, posEnd and context to null', () => {
+    const valueType = new ValueType();
+
+    expect(valueType.getPosStart()).toEqual(null);
+    expect(valueType.getPosEnd()).toEqual(null);
+    expect(valueType.getContext()).toEqual(null);
+  });
+
+  describe('setter tests', () => {
+    it('should set posStart and posEnd when calling setPos', () => {
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
+      const value = new ValueType();
+
+      value.setPos(posStart, posEnd);
+
+      expect(value.getPosStart()).toEqual(posStart);
+      expect(value.getPosEnd()).toEqual(posEnd);
+      expect(value.getContext()).toEqual(null);
+    });
+
+    it('should set context when calling setContext', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+
+      value.setContext(context);
+
+      expect(value.getPosStart()).toEqual(null);
+      expect(value.getPosEnd()).toEqual(null);
+      expect(value.getContext()).toEqual(context);
+    });
+  });
+
+  describe('addBy tests', () => {
+    it('should produce a runtime error by default when calling addBy', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.addBy(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('subtractBy tests', () => {
+    it('should produce a runtime error by default when calling subtractBy', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.subtractBy(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('multiplyBy tests', () => {
+    it('should produce a runtime error by default when calling multiplyBy', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.multiplyBy(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('divideBy tests', () => {
+    it('should produce a runtime error by default when calling divideBy', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.divideBy(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('poweredBy tests', () => {
+    it('should produce a runtime error by default when calling poweredBy', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.poweredBy(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('equalityComparison tests', () => {
+    it('should produce a runtime error by default when calling equalityComparison', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.equalityComparison(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('lessThanComparison tests', () => {
+    it('should produce a runtime error by default when calling lessThanComparison', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.lessThanComparison(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('greaterThanComparison tests', () => {
+    it('should produce a runtime error by default when calling greaterThanComparison', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.greaterThanComparison(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('lessThanOrEqualComparison tests', () => {
+    it('should produce a runtime error by default when calling lessThanOrEqualComparison', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.lessThanOrEqualComparison(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('greaterThanOrEqualComparison tests', () => {
+    it('should produce a runtime error by default when calling greaterThanOrEqualComparison', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.greaterThanOrEqualComparison(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('andBy tests', () => {
+    it('should produce a runtime error by default when calling andBy', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.andBy(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('orBy tests', () => {
+    it('should produce a runtime error by default when calling orBy', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+      const othervalue = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.orBy(othervalue);
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('notted tests', () => {
+    it('should produce a runtime error by default when calling notted', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+
+      value.setContext(context);
+      const [newvalue, error]: [ValueType, RuntimeError] = value.notted();
+
+      const expectedError = new RuntimeError('Illegal operation', null, null, context);
+
+      expect(newvalue).toEqual(null);
+      expect(error).toEqual(expectedError);
+    });
+  });
+
+  describe('execute tests', () => {
+    it('should return runtime result with illegal operation runtime error', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+
+      value.setContext(context);
+
+      const runtimeResult: RuntimeResult = value.execute();
+
+      const expectedRuntimeError = new RuntimeError('Illegal operation', null, null, context);
+      const expectedRuntimeResult = new RuntimeResult();
+      expectedRuntimeResult.failure(expectedRuntimeError);
+
+      expect(runtimeResult).toEqual(expectedRuntimeResult);
+    });
+  });
+
+  describe('isTrue tests', () => {
+    it('should return false for a ValueType when calling isTrue', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+
+      value.setContext(context);
+
+      expect(value.isTrue()).toEqual(false);
+    });
+  });
+
+  describe('copy tests', () => {
+    it('should throw an error event when calling copy', () => {
+      const context = new Context('<pseudo>');
+      const value = new ValueType();
+
+      value.setContext(context);
+
+      try {
+        value.copy();
+
+        fail('copy does not throw an error for ValueType');
+      } catch (error) {
+        expect(true).toEqual(true);
+      }
+    });
+  });
+});

--- a/src/app/data-types/value-type.ts
+++ b/src/app/data-types/value-type.ts
@@ -1,0 +1,102 @@
+import { RuntimeResult } from './../logic/runtime-result';
+import { RuntimeError } from './../logic/runtime-error';
+import { PositionTracker } from '../logic/position-tracker';
+import { Context } from '../logic/context';
+
+export class ValueType {
+  protected posStart: PositionTracker;
+  protected posEnd: PositionTracker;
+  protected context;
+
+  constructor() {
+    this.setPos(null, null);
+    this.setContext(null);
+  }
+
+  public setPos(start: PositionTracker, end: PositionTracker): ValueType {
+    this.posStart = start;
+    this.posEnd = end;
+
+    return this;
+  }
+
+  public setContext(context: Context): ValueType {
+    this.context = context;
+    return this;
+  }
+
+  public addBy(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public subtractBy(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public multiplyBy(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public divideBy(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public poweredBy(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public equalityComparison(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public lessThanComparison(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public greaterThanComparison(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public lessThanOrEqualComparison(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public greaterThanOrEqualComparison(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public andBy(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public orBy(other: ValueType): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public notted(): [ValueType, RuntimeError] {
+    return [null, this.illegalOperation()];
+  }
+
+  public execute(...args: any[]): RuntimeResult {
+    const runtimeResult = new RuntimeResult();
+    return runtimeResult.failure(this.illegalOperation());
+  }
+
+  public isTrue(): boolean { return false; }
+
+  public copy() {
+    throw new ErrorEvent('No copy method defined');
+  }
+
+  public getPosStart(): PositionTracker { return this.posStart; }
+
+  public getPosEnd(): PositionTracker { return this.posEnd; }
+
+  public getContext(): Context { return this.context; }
+
+  protected illegalOperation(): RuntimeError {
+    const runtimeError = new RuntimeError('Illegal operation', this.posStart, this.posEnd,
+                                          this.context);
+    return runtimeError;
+  }
+}

--- a/src/app/logic/lexer.spec.ts
+++ b/src/app/logic/lexer.spec.ts
@@ -678,11 +678,11 @@ describe('Lexer tests', () => {
           const eofToken: Token = createToken(TokenTypes.EOF, new PositionTracker(42, 4, 1));
 
           const tokenData: Array<[string, PositionTracker, any?]> = [
-            [TokenTypes.IDENTIFIER, posTracker1, 'function'],
+            [TokenTypes.KEYWORD, posTracker1, 'function'],
             [TokenTypes.IDENTIFIER, posTracker2, 'add'], [TokenTypes.L_BRACKET, posTracker3],
             [TokenTypes.IDENTIFIER, posTracker4, 'x'], [TokenTypes.COMMA, posTracker5],
             [TokenTypes.IDENTIFIER, posTracker6, 'y'], [TokenTypes.R_BRACKET, posTracker7],
-            [TokenTypes.IDENTIFIER, posTracker8, 'begin'], [TokenTypes.NEWLINE, posTracker9],
+            [TokenTypes.KEYWORD, posTracker8, 'begin'], [TokenTypes.NEWLINE, posTracker9],
             [TokenTypes.IDENTIFIER, posTracker10, 'return'],
             [TokenTypes.IDENTIFIER, posTracker11, 'x'], [TokenTypes.PLUS, posTracker12],
             [TokenTypes.IDENTIFIER, posTracker13, 'y'], [TokenTypes.NEWLINE, posTracker14],

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -6,6 +6,7 @@ import { Token } from '../models/token';
 import * as TokenTypes from '../constants/token-type.constants';
 import * as NodeTypes from '../constants/node-type.constants';
 import { ParseResult } from './parse-result';
+import { createToken } from '../utils/token-functions';
 
 describe('Parser tests', () => {
   describe('parse tests', () => {
@@ -3565,31 +3566,3 @@ describe('Parser tests', () => {
     });
   });
 });
-
-// Utility functions.
-function createToken(type: string, posStart: PositionTracker, value?: any): Token {
-
-  let token: Token;
-
-  const posStartNew = posStart.copy();
-  let posEnd = posStart.copy();
-  posEnd.advance();
-
-  if (value === undefined) {
-    token = {
-      type: type,
-      positionStart: posStartNew,
-      positionEnd: posEnd
-    };
-  }
-  else {
-    token = {
-      type: type,
-      positionStart: posStartNew,
-      positionEnd: posEnd,
-      value: value
-    };
-  }
-
-  return token;
-}

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -2713,6 +2713,856 @@ describe('Parser tests', () => {
         expect(parseResult).toEqual(expected);
       });
     });
+
+    describe('function definition and calls tests', () => {
+      it('should return correct AST for statement: function one() begin 1 end', () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartRightBrack = new PositionTracker(13, 1, 14);
+        const posStartBegin = new PositionTracker(15, 1, 16);
+        const posStartNum = new PositionTracker(21, 1, 22);
+        const posStartEnd = new PositionTracker(23, 1, 24);
+        const posStartEof = new PositionTracker(26, 1, 27);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'one'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.NUMBER, posStartNum, 1),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum, 1)
+        };
+        const ast: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONDEF,
+          token: createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          varNameToken: createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'one'),
+          argNameTokens: [],
+          bodyNode: numberNode
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: function add(x, y) begin x + y end', () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartVarX = new PositionTracker(13, 1, 14);
+        const posStartComma = new PositionTracker(14, 1, 15);
+        const posStartVarY = new PositionTracker(16, 1, 17);
+        const posStartRightBrack = new PositionTracker(17, 1, 18);
+        const posStartBegin = new PositionTracker(19, 1, 20);
+        const posStartVarX2 = new PositionTracker(25, 1, 26);
+        const posStartPlus = new PositionTracker(27, 1, 28);
+        const posStartVarY2 = new PositionTracker(29, 1, 30);
+        const posStartEnd = new PositionTracker(31, 1, 32);
+        const posStartEof = new PositionTracker(34, 1, 35);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const varXNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x')
+        };
+        const varYNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y')
+        };
+        const bodyNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus),
+          leftChild: varXNode,
+          rightChild: varYNode
+        };
+        const ast: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONDEF,
+          token: createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          varNameToken: createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          argNameTokens: [createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+                          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y')],
+          bodyNode: bodyNode
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 12; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      // // Anonymous function support.
+      it('should return correct AST for statement: function (x, y) begin x + y end', () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartLeftBrack = new PositionTracker(9, 1, 10);
+        const posStartVarX = new PositionTracker(10, 1, 11);
+        const posStartComma = new PositionTracker(11, 1, 12);
+        const posStartVarY = new PositionTracker(13, 1, 14);
+        const posStartRightBrack = new PositionTracker(14, 1, 15);
+        const posStartBegin = new PositionTracker(16, 1, 17);
+        const posStartVarX2 = new PositionTracker(22, 1, 23);
+        const posStartPlus = new PositionTracker(24, 1, 25);
+        const posStartVarY2 = new PositionTracker(26, 1, 27);
+        const posStartEnd = new PositionTracker(28, 1, 29);
+        const posStartEof = new PositionTracker(31, 1, 32);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const varXNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x')
+        };
+        const varYNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y')
+        };
+        const bodyNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus),
+          leftChild: varXNode,
+          rightChild: varYNode
+        };
+        const ast: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONDEF,
+          token: createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          varNameToken: null,
+          argNameTokens: [createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+                          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y')],
+          bodyNode: bodyNode
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: func = function (x, y) begin x + y end', () => {
+        const posStartVariable = new PositionTracker(0, 1, 1);
+        const posStartEquals = new PositionTracker(5, 1, 6);
+        const posStartFunction = new PositionTracker(7, 1, 8);
+        const posStartLeftBrack = new PositionTracker(16, 1, 17);
+        const posStartVarX = new PositionTracker(17, 1, 18);
+        const posStartComma = new PositionTracker(18, 1, 19);
+        const posStartVarY = new PositionTracker(20, 1, 21);
+        const posStartRightBrack = new PositionTracker(21, 1, 22);
+        const posStartBegin = new PositionTracker(23, 1, 24);
+        const posStartVarX2 = new PositionTracker(29, 1, 30);
+        const posStartPlus = new PositionTracker(31, 1, 32);
+        const posStartVarY2 = new PositionTracker(33, 1, 34);
+        const posStartEnd = new PositionTracker(35, 1, 36);
+        const posStartEof = new PositionTracker(38, 1, 39);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartVariable, 'func'),
+          createToken(TokenTypes.EQUALS, posStartEquals),
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const varXNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x')
+        };
+        const varYNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y')
+        };
+        const bodyNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus),
+          leftChild: varXNode,
+          rightChild: varYNode
+        };
+        const functionDefNode: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONDEF,
+          token: createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          varNameToken: null,
+          argNameTokens: [createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+                          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y')],
+          bodyNode: bodyNode
+        };
+
+        const ast: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVariable, 'func'),
+          node: functionDefNode
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 13; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: func(x, y, z)', () => {
+        const posStartFunc = new PositionTracker(0, 1, 1);
+        const posStartLeftBrack = new PositionTracker(4, 1, 5);
+        const posStartVarX = new PositionTracker(5, 1, 6);
+        const posStartComma1 = new PositionTracker(6, 1, 7);
+        const posStartVarY = new PositionTracker(8, 1, 9);
+        const posStartComma2 = new PositionTracker(9, 1, 10);
+        const posStartVarZ = new PositionTracker(11, 1, 12);
+        const posStartRightBrack = new PositionTracker(12, 1, 13);
+        const posStartEof = new PositionTracker(13, 1, 14);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.COMMA, posStartComma2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarZ, 'z'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const funcNameNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func')
+        };
+        const xNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x')
+        };
+        const yNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y')
+        };
+        const zNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarZ, 'z')
+        };
+        const ast: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONCALL,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func'),
+          nodeToCall: funcNameNode,
+          argNodes: [xNode, yNode, zNode]
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: func(10, 1, 2)', () => {
+        const posStartFunc = new PositionTracker(0, 1, 1);
+        const posStartLeftBrack = new PositionTracker(4, 1, 5);
+        const posStartNum1 = new PositionTracker(5, 1, 6);
+        const posStartComma1 = new PositionTracker(7, 1, 8);
+        const posStartNum2 = new PositionTracker(9, 1, 10);
+        const posStartComma2 = new PositionTracker(10, 1, 11);
+        const posStartNum3 = new PositionTracker(12, 1, 13);
+        const posStartRightBrack = new PositionTracker(13, 1, 14);
+        const posStartEof = new PositionTracker(14, 1, 15);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.NUMBER, posStartNum1, 10),
+          createToken(TokenTypes.COMMA, posStartComma1),
+          createToken(TokenTypes.NUMBER, posStartNum2, 1),
+          createToken(TokenTypes.COMMA, posStartComma2),
+          createToken(TokenTypes.NUMBER, posStartNum3, 2),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const funcNameNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func')
+        };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 10)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 1)
+        };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 2)
+        };
+        const ast: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONCALL,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func'),
+          nodeToCall: funcNameNode,
+          argNodes: [numberNode1, numberNode2, numberNode3]
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: func()', () => {
+        const posStartFunc = new PositionTracker(0, 1, 1);
+        const posStartLeftBrack = new PositionTracker(4, 1, 5);
+        const posStartRightBrack = new PositionTracker(5, 1, 6);
+        const posStartEof = new PositionTracker(6, 1, 7);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const funcNameNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func')
+        };
+        const ast: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONCALL,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFunc, 'func'),
+          nodeToCall: funcNameNode,
+          argNodes: []
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: sum = add(x, y)', () => {
+        const posStartSum = new PositionTracker(0, 1, 1);
+        const posStartEquals = new PositionTracker(4, 1, 5);
+        const posStartAdd = new PositionTracker(6, 1, 7);
+        const posStartLeftBrack = new PositionTracker(9, 1, 10);
+        const posStartVarX = new PositionTracker(10, 1, 11);
+        const posStartComma1 = new PositionTracker(11, 1, 12);
+        const posStartVarY = new PositionTracker(13, 1, 14);
+        const posStartRightBrack = new PositionTracker(14, 1, 15);
+        const posStartEof = new PositionTracker(15, 1, 16);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartSum, 'sum'),
+          createToken(TokenTypes.EQUALS, posStartEquals),
+          createToken(TokenTypes.IDENTIFIER, posStartAdd, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const funcNameNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartAdd, 'add')
+        };
+        const xNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x')
+        };
+        const yNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y')
+        };
+        const functionNode: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONCALL,
+          token: createToken(TokenTypes.IDENTIFIER, posStartAdd, 'add'),
+          nodeToCall: funcNameNode,
+          argNodes: [xNode, yNode]
+        };
+
+        const ast: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartSum, 'sum'),
+          node: functionNode
+        };
+
+        let expected = new ParseResult();
+        expected.success(ast);
+
+        for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error expected '(' in parse result for expression: function add x, y) begin x + y end`, () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartVarX = new PositionTracker(11, 1, 12);
+        const posStartComma = new PositionTracker(12, 1, 13);
+        const posStartVarY = new PositionTracker(14, 1, 15);
+        const posStartRightBrack = new PositionTracker(15, 1, 16);
+        const posStartBegin = new PositionTracker(17, 1, 18);
+        const posStartVarX2 = new PositionTracker(23, 1, 24);
+        const posStartPlus = new PositionTracker(25, 1, 26);
+        const posStartVarY2 = new PositionTracker(27, 1, 28);
+        const posStartEnd = new PositionTracker(29, 1, 30);
+        const posStartEof = new PositionTracker(32, 1, 33);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected '('`, posStartVarX,
+                                              posStartComma);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing ',' or ')' in parse result for expression: function add(x y) begin x + y end`, () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartVarX = new PositionTracker(13, 1, 14);
+        const posStartVarY = new PositionTracker(15, 1, 16);
+        const posStartRightBrack = new PositionTracker(16, 1, 17);
+        const posStartBegin = new PositionTracker(18, 1, 19);
+        const posStartVarX2 = new PositionTracker(20, 1, 21);
+        const posStartPlus = new PositionTracker(22, 1, 23);
+        const posStartVarY2 = new PositionTracker(24, 1, 25);
+        const posStartEnd = new PositionTracker(26, 1, 27);
+        const posStartEof = new PositionTracker(29, 1, 30);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected ',' or ')'`, posStartVarY,
+                                              posStartRightBrack);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing ',' or ')' in parse result for expression: function add(x, y begin x + y end`, () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartVarX = new PositionTracker(13, 1, 14);
+        const posStartComma = new PositionTracker(14, 1, 15);
+        const posStartVarY = new PositionTracker(16, 1, 17);
+        const posStartBegin = new PositionTracker(18, 1, 19);
+        const posEndBegin = new PositionTracker(19, 1, 20);
+        const posStartVarX2 = new PositionTracker(24, 1, 25);
+        const posStartPlus = new PositionTracker(26, 1, 27);
+        const posStartVarY2 = new PositionTracker(28, 1, 29);
+        const posStartEnd = new PositionTracker(30, 1, 31);
+        const posStartEof = new PositionTracker(33, 1, 34);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected ',' or ')'`, posStartBegin,
+                                              posEndBegin);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error 'Expected identifier' in parse result for expression: function add(x, ) begin x + y end`, () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartVarX = new PositionTracker(13, 1, 14);
+        const posStartComma = new PositionTracker(14, 1, 15);
+        const posStartRightBrack = new PositionTracker(16, 1, 17);
+        const posEndRightBrack = new PositionTracker(17, 1, 18);
+        const posStartBegin = new PositionTracker(18, 1, 19);
+        const posStartVarX2 = new PositionTracker(24, 1, 25);
+        const posStartPlus = new PositionTracker(26, 1, 27);
+        const posStartVarY2 = new PositionTracker(28, 1, 29);
+        const posStartEnd = new PositionTracker(30, 1, 31);
+        const posStartEof = new PositionTracker(33, 1, 34);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected identifier`, posStartRightBrack,
+                                              posEndRightBrack);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 5; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing 'begin' in parse result for expression: function add(x, y) x + y end`, () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartVarX = new PositionTracker(13, 1, 14);
+        const posStartComma = new PositionTracker(14, 1, 15);
+        const posStartVarY = new PositionTracker(16, 1, 17);
+        const posStartRightBrack = new PositionTracker(17, 1, 18);
+        const posStartVarX2 = new PositionTracker(19, 1, 20);
+        const posEndVarX2 = new PositionTracker(20, 1, 21);
+        const posStartPlus = new PositionTracker(21, 1, 22);
+        const posStartVarY2 = new PositionTracker(23, 1, 24);
+        const posStartEnd = new PositionTracker(25, 1, 26);
+        const posStartEof = new PositionTracker(28, 1, 29);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected 'begin' keyword`, posStartVarX2,
+                                              posEndVarX2);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct expression error in parse result for expression: function add(x, y) begin end`, () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartVarX = new PositionTracker(13, 1, 14);
+        const posStartComma = new PositionTracker(14, 1, 15);
+        const posStartVarY = new PositionTracker(16, 1, 17);
+        const posStartRightBrack = new PositionTracker(17, 1, 18);
+        const posStartBegin = new PositionTracker(19, 1, 20);
+        const posStartEnd = new PositionTracker(25, 1, 26);
+        const posEndEnd = new PositionTracker(26, 1, 27);
+        const posStartEof = new PositionTracker(29, 1, 30);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected a number, identifier, '+', '-', '(' ` +
+                                             `or 'NOT'`, posStartEnd, posEndEnd);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing 'end' in parse result for expression: function add(x, y) begin x + y`, () => {
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartVarX = new PositionTracker(13, 1, 14);
+        const posStartComma = new PositionTracker(14, 1, 15);
+        const posStartVarY = new PositionTracker(16, 1, 17);
+        const posStartRightBrack = new PositionTracker(17, 1, 18);
+        const posStartBegin = new PositionTracker(19, 1, 20);
+        const posStartVarX2 = new PositionTracker(25, 1, 26);
+        const posStartPlus = new PositionTracker(27, 1, 28);
+        const posStartVarY2 = new PositionTracker(29, 1, 30);
+        const posStartEof = new PositionTracker(30, 1, 31);
+        const posEndEof = new PositionTracker(31, 1, 32);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected 'end' keyword`, posStartEof, posEndEof);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error 'Expected identifier' in parse result for expression: add(x, )`, () => {
+        const posStartFuncName = new PositionTracker(0, 1, 1);
+        const posStartLeftBrack = new PositionTracker(3, 1, 4);
+        const posStartVarX = new PositionTracker(4, 1, 5);
+        const posStartComma = new PositionTracker(5, 1, 6);
+        const posStartRightBrack = new PositionTracker(7, 1, 8);
+        const posStartEof = new PositionTracker(8, 1, 9);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected a number, identifier, '+', '-', '(' ` +
+                                             `or 'NOT'`, posStartRightBrack, posStartEof);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing ',' or ')' in parse result for expression: add(x y)`, () => {
+        const posStartFuncName = new PositionTracker(0, 1, 1);
+        const posStartLeftBrack = new PositionTracker(3, 1, 4);
+        const posStartVarX = new PositionTracker(4, 1, 5);
+        const posStartVarY = new PositionTracker(6, 1, 7);
+        const posStartRightBrack = new PositionTracker(7, 1, 8);
+        const posStartEof = new PositionTracker(8, 1, 9);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected ',' or ')'`, posStartVarY,
+                                              posStartRightBrack);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it(`should return correct error missing ',' or ')' in parse result for expression: add(x, y`, () => {
+        const posStartFuncName = new PositionTracker(0, 1, 1);
+        const posStartLeftBrack = new PositionTracker(3, 1, 4);
+        const posStartVarX = new PositionTracker(4, 1, 5);
+        const posStartComma = new PositionTracker(5, 1, 6);
+        const posStartVarY = new PositionTracker(7, 1, 8);
+        const posStartEof = new PositionTracker(8, 1, 9);
+        const posEndEof = new PositionTracker(9, 1, 10);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected ',' or ')'`, posStartEof, posEndEof);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 5; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+    });
   });
 });
 

--- a/src/app/logic/runtime-result.spec.ts
+++ b/src/app/logic/runtime-result.spec.ts
@@ -1,3 +1,4 @@
+import { ValueType } from './../data-types/value-type';
 import { Context } from './context';
 import { PositionTracker } from './position-tracker';
 import { RuntimeError } from './runtime-error';
@@ -48,7 +49,7 @@ describe('RuntimeResult tests', () => {
       const otherRuntimeResult = new RuntimeResult();
 
       otherRuntimeResult.success(number);
-      const returnedValue: NumberType = runtimeResult.register(otherRuntimeResult);
+      const returnedValue: ValueType = runtimeResult.register(otherRuntimeResult);
 
       expect(returnedValue).toEqual(number);
       expect(runtimeResult.getValue()).toEqual(null);
@@ -64,7 +65,7 @@ describe('RuntimeResult tests', () => {
       const otherRuntimeResult = new RuntimeResult();
 
       otherRuntimeResult.failure(runtimeError);
-      const returnedValue: NumberType = runtimeResult.register(otherRuntimeResult);
+      const returnedValue: ValueType = runtimeResult.register(otherRuntimeResult);
 
       expect(returnedValue).toEqual(null);
       expect(runtimeResult.getValue()).toEqual(null);

--- a/src/app/logic/runtime-result.ts
+++ b/src/app/logic/runtime-result.ts
@@ -1,16 +1,16 @@
 import { RuntimeError } from './runtime-error';
-import { NumberType } from './../data-types/number-type';
+import { ValueType } from '../data-types/value-type';
 
 export class RuntimeResult {
-  private value: NumberType = null;
+  private value: ValueType = null;
   private error: RuntimeError = null;
 
-  public register(result: RuntimeResult): NumberType {
+  public register(result: RuntimeResult): ValueType {
     if (result.getError() !== null) { this.error = result.getError(); }
     return result.value;
   }
 
-  public success(value: NumberType): RuntimeResult {
+  public success(value: ValueType): RuntimeResult {
     this.value = value;
     return this;
   }
@@ -20,7 +20,7 @@ export class RuntimeResult {
     return this;
   }
 
-  public getValue(): NumberType { return this.value; }
+  public getValue(): ValueType { return this.value; }
 
   public getError(): RuntimeError { return this.error; }
 }

--- a/src/app/logic/symbol-table.spec.ts
+++ b/src/app/logic/symbol-table.spec.ts
@@ -3,13 +3,22 @@ import { NumberType } from './../data-types/number-type';
 import { SymbolTable } from './symbol-table';
 
 describe('SymbolTable tests', () => {
-  it('should initialise with an empty symbols map and null parent', () => {
+  it('should initialise with an empty symbols map and null parent (if not passed)', () => {
     const symbolTable = new SymbolTable();
     const expectedSymbols = new Map<string, NumberType>();
     const expectedParentTable: SymbolTable = null;
 
     expect(symbolTable.getSymbols()).toEqual(expectedSymbols);
     expect(symbolTable.getParent()).toEqual(expectedParentTable);
+  });
+
+  it('should initialise with an empty symbols map and a parent when passed', () => {
+    const parentSymbolTable = new SymbolTable();
+    const symbolTable = new SymbolTable(parentSymbolTable);
+    const expectedSymbols = new Map<string, NumberType>();
+
+    expect(symbolTable.getSymbols()).toEqual(expectedSymbols);
+    expect(symbolTable.getParent()).toEqual(parentSymbolTable);
   });
 
   describe('set and get tests', () => {
@@ -35,6 +44,17 @@ describe('SymbolTable tests', () => {
       expect(value2).toEqual(new NumberType(20));
       expect(value3).toEqual(new NumberType(100));
       expect(value4).toEqual(undefined);
+    });
+
+    it('should return correct value for getting an existing value in the parent SymbolTable', () => {
+      const parentSymbolTable = new SymbolTable();
+
+      parentSymbolTable.set('globalVar', new NumberType(0));
+
+      const symbolTable = new SymbolTable(parentSymbolTable);
+      const value: ValueType = symbolTable.get('globalVar');
+
+      expect(value).toEqual(new NumberType(0));
     });
   });
 

--- a/src/app/logic/symbol-table.spec.ts
+++ b/src/app/logic/symbol-table.spec.ts
@@ -1,3 +1,4 @@
+import { ValueType } from './../data-types/value-type';
 import { NumberType } from './../data-types/number-type';
 import { SymbolTable } from './symbol-table';
 
@@ -14,7 +15,7 @@ describe('SymbolTable tests', () => {
   describe('set and get tests', () => {
     it('should return undefined value for trying to get from an empty SymbolTable', () => {
       const symbolTable = new SymbolTable();
-      const value: NumberType = symbolTable.get('variable');
+      const value: ValueType = symbolTable.get('variable');
 
       expect(value).toEqual(undefined);
     });
@@ -25,10 +26,10 @@ describe('SymbolTable tests', () => {
       symbolTable.set('variable2', new NumberType(20));
       symbolTable.set('variable3', new NumberType(100));
 
-      const value1: NumberType = symbolTable.get('variable');
-      const value2: NumberType = symbolTable.get('variable2');
-      const value3: NumberType = symbolTable.get('variable3');
-      const value4: NumberType = symbolTable.get('var');
+      const value1: ValueType = symbolTable.get('variable');
+      const value2: ValueType = symbolTable.get('variable2');
+      const value3: ValueType = symbolTable.get('variable3');
+      const value4: ValueType = symbolTable.get('var');
 
       expect(value1).toEqual(new NumberType(10));
       expect(value2).toEqual(new NumberType(20));
@@ -61,9 +62,9 @@ describe('SymbolTable tests', () => {
 
       symbolTable.remove('variable');
 
-      const value1: NumberType = symbolTable.get('variable');
-      const value2: NumberType = symbolTable.get('variable2');
-      const value3: NumberType = symbolTable.get('variable3');
+      const value1: ValueType = symbolTable.get('variable');
+      const value2: ValueType = symbolTable.get('variable2');
+      const value3: ValueType = symbolTable.get('variable3');
 
       expect(value1).toEqual(undefined);
       expect(value2).toEqual(new NumberType(20));

--- a/src/app/logic/symbol-table.ts
+++ b/src/app/logic/symbol-table.ts
@@ -1,24 +1,24 @@
-import { NumberType } from './../data-types/number-type';
+import { ValueType } from '../data-types/value-type';
 
 export class SymbolTable {
 
-  private symbols: Map<string, NumberType> = new Map<string, NumberType>();
+  private symbols: Map<string, ValueType> = new Map<string, ValueType>();
   private parent: SymbolTable = null;
 
-  public get(variableName: string): NumberType {
-    const value: NumberType = this.symbols.get(variableName);
+  public get(variableName: string): ValueType {
+    const value: ValueType = this.symbols.get(variableName);
     if (value === undefined && this.parent !== null) { return this.parent.get(variableName); }
 
     return value;
   }
 
-  public set(variableName: string, value: NumberType): void {
+  public set(variableName: string, value: ValueType): void {
     this.symbols.set(variableName, value);
   }
 
   public remove(variableName: string): void { this.symbols.delete(variableName); }
 
-  public getSymbols(): Map<string, NumberType> { return this.symbols }
+  public getSymbols(): Map<string, ValueType> { return this.symbols }
 
   public getParent(): SymbolTable { return this.parent }
 }

--- a/src/app/logic/symbol-table.ts
+++ b/src/app/logic/symbol-table.ts
@@ -5,6 +5,10 @@ export class SymbolTable {
   private symbols: Map<string, ValueType> = new Map<string, ValueType>();
   private parent: SymbolTable = null;
 
+  constructor(parent?: SymbolTable) {
+    this.parent = parent === undefined ? null : parent;
+  }
+
   public get(variableName: string): ValueType {
     const value: ValueType = this.symbols.get(variableName);
     if (value === undefined && this.parent !== null) { return this.parent.get(variableName); }

--- a/src/app/models/ast-node.ts
+++ b/src/app/models/ast-node.ts
@@ -14,5 +14,8 @@ export interface ASTNode {
   endValueNode?: ASTNode,
   stepValueNode?: ASTNode,
   conditionNode?: ASTNode,
-  bodyNode?: ASTNode
+  bodyNode?: ASTNode,
+  argNameTokens?: Token[],
+  nodeToCall?: ASTNode,
+  argNodes?: ASTNode[]
 }

--- a/src/app/models/function-call-node.ts
+++ b/src/app/models/function-call-node.ts
@@ -1,0 +1,9 @@
+import { ASTNode } from './ast-node';
+import { Token } from './token';
+
+export interface FunctionCallNode extends ASTNode {
+  nodeType: string,
+  token: Token,
+  nodeToCall: ASTNode,
+  argNodes: ASTNode[]
+}

--- a/src/app/models/function-def-node.ts
+++ b/src/app/models/function-def-node.ts
@@ -1,0 +1,10 @@
+import { ASTNode } from './ast-node';
+import { Token } from './token';
+
+export interface FunctionDefNode extends ASTNode {
+  nodeType: string,
+  token: Token,
+  varNameToken: Token,
+  argNameTokens: Token[],
+  bodyNode: ASTNode
+}

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -705,5 +705,46 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual(expectedErr);
       });
     });
+
+    describe('function definition and calls tests', () => {
+      it('should return function value by its name, when defined, in the shell output', () => {
+        service = new InterpreterService();
+        const source = 'function add(x, y) begin x + y end';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('');
+        expect(shellOut).toEqual('function add');
+      });
+
+      it('should return function value by its name <anonymous>, when defined, in the shell output', () => {
+        service = new InterpreterService();
+        const source = 'function (x, y) begin x + y end';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('');
+        expect(shellOut).toEqual('function <anonymous>');
+      });
+
+      // TODO: Add tests for normal function calls after supporting multiline code.
+      // it('should return function output in the shell output when called', () => {
+
+      // });
+
+      it('should return a runtime error for calling a none FunctionType', () => {
+        service = new InterpreterService();
+        const source = 'randomFunc(x)';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        const expectedError = `Traceback (most recent call last):\nLine 2, in <pseudo>\nRuntime` +
+                              ` Error: Can not make a call to a none FunctionType\nAt line: 1 ` +
+                              `column: 1 and ends at line: 1 column: 2`;
+
+        expect(consoleOut).toEqual(expectedError);
+        expect(shellOut).toEqual(expectedError);
+      });
+    });
   });
 });

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -74,16 +74,7 @@ export class InterpreterService {
     return [consoleOutput, shellOutput];
   }
 
-  private initialiseGlobalSymbolTable(): SymbolTable {
-    const globalSymbolTable = new SymbolTable();
-    globalSymbolTable.set('TRUE', new NumberType(1));
-    globalSymbolTable.set('FALSE', new NumberType(0));
-    globalSymbolTable.set('PI', new NumberType(Math.PI));
-
-    return globalSymbolTable;
-  }
-
-  private visitNode(node: ASTNode, context: Context): RuntimeResult {
+  public visitNode(node: ASTNode, context: Context): RuntimeResult {
     switch (node.nodeType) {
       case NodeTypes.NUMBER:
         return this.visitNumberNode(node, context);
@@ -105,6 +96,15 @@ export class InterpreterService {
         this.noVisitNode();
         break;
     }
+  }
+
+  private initialiseGlobalSymbolTable(): SymbolTable {
+    const globalSymbolTable = new SymbolTable();
+    globalSymbolTable.set('TRUE', new NumberType(1));
+    globalSymbolTable.set('FALSE', new NumberType(0));
+    globalSymbolTable.set('PI', new NumberType(Math.PI));
+
+    return globalSymbolTable;
   }
 
   private visitWhileNode(node: ASTNode, context: Context): RuntimeResult {

--- a/src/app/utils/token-functions.ts
+++ b/src/app/utils/token-functions.ts
@@ -1,0 +1,29 @@
+import { PositionTracker } from "../logic/position-tracker";
+import { Token } from '../models/token';
+
+export function createToken(type: string, posStart: PositionTracker, value?: any): Token {
+
+  let token: Token;
+
+  const posStartNew = posStart.copy();
+  let posEnd = posStart.copy();
+  posEnd.advance();
+
+  if (value === undefined) {
+    token = {
+      type: type,
+      positionStart: posStartNew,
+      positionEnd: posEnd
+    };
+  }
+  else {
+    token = {
+      type: type,
+      positionStart: posStartNew,
+      positionEnd: posEnd,
+      value: value
+    };
+  }
+
+  return token;
+}


### PR DESCRIPTION
The language now supports functions definitions and functions calls. This is the following syntax for function definitions (second bullet point demonstrates anonymous functions):

- function [function-name] ([args]) begin [body] end
- function ([args]) begin [body] end 

This is the syntax for function calls:

- [function-name] ([args])

The language also handles runtime errors such as mismatching number of arguments passed and incorrect syntax. There has also been some refactoring of the data types of the language to include `ValueType` which is the parent data type of all other data types in Pseudo. This is to prevent illegal operation errors such as adding a `NumberType` with a `FunctionType`. `SymbolTable` was also refactored to allow a parent `SymbolTable` to be passed to the constructor for local scope support.