### PR TITLE
feat(strings): added basic string data type support

### DIFF
--- a/src/app/constants/node-type.constants.ts
+++ b/src/app/constants/node-type.constants.ts
@@ -1,4 +1,5 @@
 export const NUMBER = 'NumberNode';
+export const STRING = 'StringNode';
 export const BINARYOP = 'BinaryOpNode';
 export const UNARYOP = 'UnaryOpNode';
 export const VARACCESS = 'VarAccessNode';

--- a/src/app/constants/token-type.constants.ts
+++ b/src/app/constants/token-type.constants.ts
@@ -6,6 +6,7 @@ export const POWER = 'POWER';
 export const L_BRACKET = 'L_BRACKET';
 export const R_BRACKET = 'R_BRACKET';
 export const NUMBER = 'NUMBER';
+export const STRING = 'STRING';
 export const NEWLINE = 'NEWLINE';
 export const IDENTIFIER = 'IDENTIFIER';
 export const KEYWORD = 'KEYWORD';

--- a/src/app/data-types/function-type.spec.ts
+++ b/src/app/data-types/function-type.spec.ts
@@ -89,7 +89,7 @@ describe('FunctionType tests', () => {
 
       const result: RuntimeResult = functionType.execute([number1]);
 
-      const expectedErrorMessage = `Traceback (most recent call last):\nLine 2, in add\nRuntime` +
+      const expectedErrorMessage = `Traceback (most recent call last):\nLine 1, in add\nRuntime` +
                                    ` Error: 1 arguments were passed into add. Expected 2\n` +
                                    `At line: 1 column: 1 and ends at line: 1 column: 2`;
 
@@ -135,7 +135,7 @@ describe('FunctionType tests', () => {
 
       const result: RuntimeResult = functionType.execute([number1, number2, number3]);
 
-      const expectedErrorMessage = `Traceback (most recent call last):\nLine 2, in add\nRuntime` +
+      const expectedErrorMessage = `Traceback (most recent call last):\nLine 1, in add\nRuntime` +
                                    ` Error: 3 arguments were passed into add. Expected 2\n` +
                                    `At line: 1 column: 1 and ends at line: 1 column: 2`;
 

--- a/src/app/data-types/string-type.spec.ts
+++ b/src/app/data-types/string-type.spec.ts
@@ -1,0 +1,145 @@
+import { NumberType } from './number-type';
+import { StringType } from './string-type';
+import { PositionTracker } from '../logic/position-tracker';
+import { Context } from '../logic/context';
+import { ValueType } from './value-type';
+import { RuntimeError } from '../logic/runtime-error';
+
+describe('StringType tests', () => {
+  it('should initialise with passed value but with null position tracker and context', () => {
+    const str = new StringType('hello world');
+
+    expect(str.getValue()).toEqual('hello world');
+    expect(str.getPosStart()).toEqual(null);
+    expect(str.getPosEnd()).toEqual(null);
+    expect(str.getContext()).toEqual(null);
+  });
+
+  describe('setter tests', () => {
+    it('should set posStart and posEnd when calling setPos', () => {
+      const posStart = new PositionTracker(0, 1, 1);
+      const posEnd = new PositionTracker(1, 1, 2);
+      const str = new StringType('some string');
+
+      str.setPos(posStart, posEnd);
+
+      expect(str.getValue()).toEqual('some string');
+      expect(str.getPosStart()).toEqual(posStart);
+      expect(str.getPosEnd()).toEqual(posEnd);
+      expect(str.getContext()).toEqual(null);
+    });
+
+    it('should set context when calling setContext', () => {
+      const context = new Context('<pseudo>');
+      const str = new StringType('random string');
+
+      str.setContext(context);
+
+      expect(str.getValue()).toEqual('random string');
+      expect(str.getPosStart()).toEqual(null);
+      expect(str.getPosEnd()).toEqual(null);
+      expect(str.getContext()).toEqual(context);
+    });
+  });
+
+  describe('copy tests', () => {
+    it('should create a new copied instance of the NumberType when calling copy', () => {
+      const str = new StringType('some string');
+      const copiedString = str.copy();
+
+      expect(str).toEqual(copiedString);
+
+      const startPos = new PositionTracker(0, 1, 1);
+      const endPos = new PositionTracker(1, 1, 2);
+      copiedString.setPos(startPos, endPos);
+
+      expect(str.getPosStart()).toEqual(null);
+      expect(str.getPosEnd()).toEqual(null);
+      expect(copiedString.getPosStart()).toEqual(startPos);
+      expect(copiedString.getPosEnd()).toEqual(endPos);
+    });
+  });
+
+  describe('addBy tests', () => {
+    it('should return StringType with concatenated value and common context', () => {
+      const context = new Context('<pseudo>');
+      const str = new StringType('hello ');
+      const otherString = new StringType('world!');
+
+      str.setContext(context);
+      const [newString, error]: [ValueType, RuntimeError] = str.addBy(otherString);
+
+      if (newString instanceof StringType) {
+        expect(newString.getValue()).toEqual('hello world!');
+      }
+      else { fail('newString is not an instance of NumberType'); }
+
+      expect(newString.getPosStart()).toEqual(null);
+      expect(newString.getPosEnd()).toEqual(null);
+      expect(newString.getContext()).toEqual(context);
+      expect(error).toEqual(null);
+    });
+  });
+
+  describe('multiplyBy tests', () => {
+    it('should return StringType with multiplied number of text for the string and common context', () => {
+      const context = new Context('<pseudo>');
+      const str = new StringType('hello! ');
+      const number = new NumberType(3);
+
+      str.setContext(context);
+      const [newString, error]: [ValueType, RuntimeError] = str.multiplyBy(number);
+
+      if (newString instanceof StringType) {
+        expect(newString.getValue()).toEqual('hello! hello! hello! ');
+      }
+      else { fail('newString is not an instance of NumberType'); }
+
+      expect(newString.getPosStart()).toEqual(null);
+      expect(newString.getPosEnd()).toEqual(null);
+      expect(newString.getContext()).toEqual(context);
+      expect(error).toEqual(null);
+    });
+
+    it('should return StringType with empty string when multiplied by 0 and common context', () => {
+      const context = new Context('<pseudo>');
+      const str = new StringType('hello! ');
+      const number = new NumberType(0);
+
+      str.setContext(context);
+      const [newString, error]: [ValueType, RuntimeError] = str.multiplyBy(number);
+
+      if (newString instanceof StringType) {
+        expect(newString.getValue()).toEqual('');
+      }
+      else { fail('newString is not an instance of NumberType'); }
+
+      expect(newString.getPosStart()).toEqual(null);
+      expect(newString.getPosEnd()).toEqual(null);
+      expect(newString.getContext()).toEqual(context);
+      expect(error).toEqual(null);
+    });
+  });
+
+  describe('isTrue tests', () => {
+    it('should return NumberType with value of 1 for strings of length greater than 0', () => {
+      const context = new Context('<pseudo>');
+      const str = new StringType('hello');
+
+      str.setContext(context);
+      const result: boolean = str.isTrue();
+
+      expect(result).toEqual(true);
+    });
+
+    it('should return NumberType with value of 0 for strings of length 0', () => {
+      const context = new Context('<pseudo>');
+      const str = new StringType('');
+
+      str.setContext(context);
+      const result: boolean = str.isTrue();
+
+      expect(result).toEqual(false);
+    });
+  });
+});

--- a/src/app/data-types/string-type.ts
+++ b/src/app/data-types/string-type.ts
@@ -1,0 +1,37 @@
+import { NumberType } from './number-type';
+import { RuntimeError } from './../logic/runtime-error';
+import { ValueType } from './value-type';
+
+export class StringType extends ValueType {
+
+  constructor(private value: string) {
+    super();
+  }
+
+  public addBy(other: ValueType): [ValueType, RuntimeError] {
+    if (other instanceof StringType) {
+      return [new StringType(this.value + other.getValue()).setContext(this.context), null];
+    }
+    else { return [null, this.illegalOperation()]; }
+  }
+
+  public multiplyBy(other: ValueType): [ValueType, RuntimeError] {
+    if (other instanceof NumberType) {
+      return [new StringType(this.value.repeat(other.getValue())).setContext(this.context), null];
+    }
+    else { return [null, this.illegalOperation()]; }
+  }
+
+  public isTrue(): boolean { return this.value.length > 0; }
+
+  public copy(): StringType {
+    const str = new StringType(this.value);
+
+    str.setPos(this.posStart, this.posEnd);
+    str.setContext(this.context);
+
+    return str;
+  }
+
+  public getValue(): string { return this.value; }
+}

--- a/src/app/data-types/string-type.ts
+++ b/src/app/data-types/string-type.ts
@@ -17,6 +17,10 @@ export class StringType extends ValueType {
 
   public multiplyBy(other: ValueType): [ValueType, RuntimeError] {
     if (other instanceof NumberType) {
+      if (other.getValue() < 0) {
+        return [null, new RuntimeError('Multiplied string by negative value', other.getPosStart(),
+                                        other.getPosEnd(), other.getContext())];
+      }
       return [new StringType(this.value.repeat(other.getValue())).setContext(this.context), null];
     }
     else { return [null, this.illegalOperation()]; }

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -849,6 +849,33 @@ describe('Parser tests', () => {
       });
     });
 
+    describe('string expression tests', () => {
+      it('should return correct AST for expression: "some string"', () => {
+        const posStartString = new PositionTracker(0, 1, 1);
+        const posStartEof = new PositionTracker(13, 1, 14);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.STRING, posStartString, 'some string'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const ast: ASTNode = {
+          nodeType: NodeTypes.STRING,
+          token: createToken(TokenTypes.STRING, posStartString, 'some string')
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        expected.registerAdvancement();
+
+        expect(parseResult).toEqual(expected);
+      });
+    });
+
     describe('variable assignment tests', () => {
       it('should return correct AST for statement: variable = 1', () => {
         const posStartVariable = new PositionTracker(0, 1, 1);
@@ -1096,6 +1123,41 @@ describe('Parser tests', () => {
         expected = expected.success(ast);
 
         for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult).toEqual(expected);
+      });
+
+      it('should return correct AST for statement: x = "some string"', () => {
+        const posStartVariable = new PositionTracker(0, 1, 1);
+        const posStartEquals = new PositionTracker(2, 1, 3);
+        const posStartString = new PositionTracker(4, 1, 5);
+        const posStartEof = new PositionTracker(17, 1, 18);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartVariable, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals),
+          createToken(TokenTypes.STRING, posStartString, 'some string'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const stringNode: ASTNode = {
+          nodeType: NodeTypes.STRING,
+          token: createToken(TokenTypes.STRING, posStartString, 'some string')
+        };
+
+        const ast: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVariable, 'x'),
+          node: stringNode
+        };
+
+        let expected = new ParseResult();
+        expected = expected.success(ast);
+
+        for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
         expect(parseResult).toEqual(expected);
       });

--- a/src/app/logic/parser.ts
+++ b/src/app/logic/parser.ts
@@ -1,3 +1,4 @@
+import { StringNode } from './../models/string-node';
 import { FunctionDefNode } from './../models/function-def-node';
 import { ForNode } from './../models/for-node';
 import { IfNode } from './../models/if-node';
@@ -424,6 +425,12 @@ export class Parser {
       this.advance();
       let numberNode: NumberNode = { nodeType: NodeTypes.NUMBER, token: tok };
       return parseResult.success(numberNode);
+    }
+    else if (tok.type === TokenTypes.STRING) {
+      parseResult.registerAdvancement();
+      this.advance();
+      let stringNode: StringNode = { nodeType: NodeTypes.STRING, token: tok };
+      return parseResult.success(stringNode);
     }
     else if (tok.type === TokenTypes.IDENTIFIER || tok.value === 'TRUE' ||
                                                     tok.value === 'FALSE') {

--- a/src/app/logic/runtime-error.spec.ts
+++ b/src/app/logic/runtime-error.spec.ts
@@ -13,7 +13,7 @@ describe('RuntimeError tests', () => {
                               `${posStart.getColumn()} and ends at line: ` +
                               `${posEnd.getLine()} column: ${posEnd.getColumn()}`;
 
-      const expected = `Traceback (most recent call last):\nLine ${posStart.getLine() + 1}, ` +
+      const expected = `Traceback (most recent call last):\nLine ${posStart.getLine()}, ` +
                        `in ${context.getContextName()}\nRuntime Error: Division by zero\n` +
                        `${positionDetails}`;
 
@@ -32,9 +32,9 @@ describe('RuntimeError tests', () => {
                               `${posEnd.getLine()} column: ${posEnd.getColumn()}`;
 
       const tracebackDetails = `Traceback (most recent call last):\nLine ` +
-                               `${posStartParent.getLine() + 1}, in ` +
+                               `${posStartParent.getLine()}, in ` +
                                `${parentContext.getContextName()}\nLine ` +
-                               `${posStart.getLine() + 1}, in ${context.getContextName()}\n`;
+                               `${posStart.getLine()}, in ${context.getContextName()}\n`;
 
       const expected = `${tracebackDetails}Runtime Error: Division by zero\n${positionDetails}`;
 

--- a/src/app/logic/runtime-error.ts
+++ b/src/app/logic/runtime-error.ts
@@ -25,7 +25,7 @@ export class RuntimeError extends Error {
     let ctx = this.context;
 
     while (ctx !== null) {
-      result = `Line ${pos.getLine() + 1}, in ${ctx.getContextName()}\n` + result;
+      result = `Line ${pos.getLine()}, in ${ctx.getContextName()}\n` + result;
       pos = ctx.getParentEntryPos();
       ctx = ctx.getParent();
     }

--- a/src/app/models/string-node.ts
+++ b/src/app/models/string-node.ts
@@ -1,0 +1,7 @@
+import { ASTNode } from './ast-node';
+import { Token } from './token';
+
+export interface StringNode extends ASTNode {
+  nodeType: string,
+  token: Token
+}

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -138,9 +138,129 @@ describe('InterpreterService', () => {
 
           const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
-          const expectedErr = `Traceback (most recent call last):\nLine 2, in <pseudo>\n` +
+          const expectedErr = `Traceback (most recent call last):\nLine 1, in <pseudo>\n` +
                               `Runtime Error: Division by zero\nAt line: 1 column: 6 and ends` +
                               ` at line: 1 column: 7`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+      });
+    });
+
+    describe('string expression tests', () => {
+      describe('valid string expression tests', () => {
+        it(`should return empty console output with shell output 'string' for expression: "string"`, () => {
+          service = new InterpreterService();
+          const source = '"string"';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('string');
+        });
+
+        it(`should return empty console output with shell output 'string \t " \n' for expression: "string \t \\" \n"`, () => {
+          service = new InterpreterService();
+          const source = '"string \t \\" \n"';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('string \t " \n');
+        });
+
+        it(`should return empty console output with shell output 'string concat' for expression: "string" + " concat"`, () => {
+          service = new InterpreterService();
+          const source = '"string" + " concat"';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('string concat');
+        });
+
+        it(`should return empty console output with shell output 'hello hello ' for expression: "hello " * 2`, () => {
+          service = new InterpreterService();
+          const source = '"hello " * 2';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('hello hello ');
+        });
+
+        it(`should return empty console output with shell output '' for expression: "hello " * 0`, () => {
+          service = new InterpreterService();
+          const source = '"hello " * 0';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('');
+        });
+
+        it(`should return empty console output with shell output 'hello! hello! World!' for expression: "hello! " * 2 + "World!"`, () => {
+          service = new InterpreterService();
+          const source = '"hello! " * 2 + "World!"';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('hello! hello! World!');
+        });
+      });
+
+      describe('erroneous string expression tests', () => {
+        it('should return syntax error in console/shell output for expression: "hello', () => {
+          service = new InterpreterService();
+          const source = '"hello';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidCharacterError: missing closing " in string\n` +
+                              `At line: 1 column: 7 and ends at line: 1 column: 8`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+
+        it('should return syntax error in console/shell output for expression: "hello\\"', () => {
+          service = new InterpreterService();
+          const source = '"hello\\"';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `InvalidCharacterError: missing closing " in string\n` +
+                              `At line: 1 column: 9 and ends at line: 1 column: 10`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+
+        it('should return runtime error in console/shell output for expression: "age: " + 1', () => {
+          service = new InterpreterService();
+          const source = '"age: " + 1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `Traceback (most recent call last):\nLine 1, in <pseudo>\nRuntime` +
+                              ` Error: Illegal operation\nAt line: 1 column: 1 and ends at ` +
+                              `line: 1 column: 2`;
+
+          expect(consoleOut).toEqual(expectedErr);
+          expect(shellOut).toEqual(expectedErr);
+        });
+
+        it('should return runtime error in console/shell output for expression: "hello" * -1', () => {
+          service = new InterpreterService();
+          const source = '"hello" * -1';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          const expectedErr = `Traceback (most recent call last):\nLine 1, in <pseudo>\nRuntime` +
+                              ` Error: Multiplied string by negative value\nAt line: 1 column: ` +
+                              `11 and ends at line: 1 column: 12`;
 
           expect(consoleOut).toEqual(expectedErr);
           expect(shellOut).toEqual(expectedErr);
@@ -158,6 +278,16 @@ describe('InterpreterService', () => {
 
           expect(consoleOut).toEqual('');
           expect(shellOut).toEqual('1');
+        });
+
+        it(`should produce shell output of 'string' for expression: var = "string"`, () => {
+          service = new InterpreterService();
+          const source = 'var = "string"';
+
+          const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+          expect(consoleOut).toEqual('');
+          expect(shellOut).toEqual('string');
         });
 
         it(`should produce shell output of '-27' for expression: var = -((1 + 0.5) / (1 - 0.5)) ^ 3`, () => {
@@ -245,7 +375,7 @@ describe('InterpreterService', () => {
 
           const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
-          const expectedErr = `Traceback (most recent call last):\nLine 2, in <pseudo>\n` +
+          const expectedErr = `Traceback (most recent call last):\nLine 1, in <pseudo>\n` +
                               `Runtime Error: x is not defined\nAt line: 1 column: 1 and` +
                               ` ends at line: 1 column: 2`;
 
@@ -738,7 +868,7 @@ describe('InterpreterService', () => {
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
-        const expectedError = `Traceback (most recent call last):\nLine 2, in <pseudo>\nRuntime` +
+        const expectedError = `Traceback (most recent call last):\nLine 1, in <pseudo>\nRuntime` +
                               ` Error: Can not make a call to a none FunctionType\nAt line: 1 ` +
                               `column: 1 and ends at line: 1 column: 2`;
 

--- a/src/app/utils/token-functions.ts
+++ b/src/app/utils/token-functions.ts
@@ -27,3 +27,23 @@ export function createToken(type: string, posStart: PositionTracker, value?: any
 
   return token;
 }
+
+export function createTokenArray(tokenData: Array<[string, PositionTracker, any?]>): Array<Token> {
+
+  let tokens: Array<Token> = [];
+
+  for (let data of tokenData) {
+    let token: Token;
+
+    if (data.length === 2) {
+      token = createToken(data[0], data[1]);
+    }
+    else {
+      token = createToken(data[0], data[1], data[2]);
+    }
+
+    tokens.push(token);
+  }
+
+  return tokens;
+}


### PR DESCRIPTION
The language now supports string data types and a couple of basic functionalities for strings. The syntax for a string is:

- "[string-text]"

Strings in Pseudo also support the tab character `'\t'` and the newline character `'\n'`. They also support the escape character `\` to allow strings such as `'string with double quote "'` to be written in pseudo as `"string with double quote \""`. There is also string concatenation and multiplication supported such as:

- `"hello " + "world"` which gives `"hello world"`.
- `"hello " * 3` which gives `"hello hello hello "`.
- `"hello" * 0` which gives `""`.
- `"hello" * -1` which gives a runtime error for using negative multiplier.

There is also error messages for missing double quotes in strings. Single quotes are not supported as string delimiters.

