### PR TITLE
feat(multi-line-statements): added multi-line code support + block code support

### DIFF
--- a/src/app/data-types/function-type.spec.ts
+++ b/src/app/data-types/function-type.spec.ts
@@ -8,6 +8,7 @@ import * as NodeTypes from '../constants/node-type.constants';
 import * as TokenTypes from '../constants/token-type.constants';
 import {createToken} from '../utils/token-functions';
 import { SymbolTable } from '../logic/symbol-table';
+import { InterpreterService } from '../services/interpreter.service';
 
 describe('FunctionType tests', () => {
   describe('execute tests', () => {
@@ -47,7 +48,8 @@ describe('FunctionType tests', () => {
       functionType.getContext().symbolTable.set('x', number1);
       functionType.getContext().symbolTable.set('y', number2);
 
-      const value: NumberType = <NumberType>functionType.execute([number1, number2]).getValue();
+      const interpreter = new InterpreterService();
+      const value: NumberType = <NumberType>functionType.execute([number1, number2], interpreter).getValue();
       expect(value.getValue()).toEqual(3);
     });
 
@@ -87,7 +89,8 @@ describe('FunctionType tests', () => {
       functionType.getContext().symbolTable.set('x', number1);
       functionType.getContext().symbolTable.set('y', number2);
 
-      const result: RuntimeResult = functionType.execute([number1]);
+      const interpreter = new InterpreterService();
+      const result: RuntimeResult = functionType.execute([number1], interpreter);
 
       const expectedErrorMessage = `Traceback (most recent call last):\nLine 1, in add\nRuntime` +
                                    ` Error: 1 arguments were passed into add. Expected 2\n` +
@@ -133,7 +136,8 @@ describe('FunctionType tests', () => {
       functionType.getContext().symbolTable.set('x', number1);
       functionType.getContext().symbolTable.set('y', number2);
 
-      const result: RuntimeResult = functionType.execute([number1, number2, number3]);
+      const interpreter = new InterpreterService();
+      const result: RuntimeResult = functionType.execute([number1, number2, number3], interpreter);
 
       const expectedErrorMessage = `Traceback (most recent call last):\nLine 1, in add\nRuntime` +
                                    ` Error: 3 arguments were passed into add. Expected 2\n` +

--- a/src/app/data-types/function-type.ts
+++ b/src/app/data-types/function-type.ts
@@ -14,9 +14,8 @@ export class FunctionType extends ValueType {
     this.name = name === undefined ? '<anonymous>' : name;
   }
 
-  public execute(args: ValueType[]): RuntimeResult {
+  public execute(args: ValueType[], interpreter: InterpreterService): RuntimeResult {
     let runtimeResult = new RuntimeResult();
-    const interpreter = new InterpreterService();
     let newContext = new Context(this.name, this.context, this.posStart);
 
     newContext.symbolTable = new SymbolTable(newContext.getParent().symbolTable);

--- a/src/app/logic/parse-result.spec.ts
+++ b/src/app/logic/parse-result.spec.ts
@@ -75,6 +75,34 @@ describe('ParseResult tests', () => {
     });
   });
 
+  describe('tryRegister tests', () => {
+    it('should update reverseToCount and return null when passing in an error result', () => {
+      const posStart = new PositionTracker(4, 1, 5);
+      const posEnd = new PositionTracker(5, 1, 6);
+      const syntaxError = new InvalidSyntaxError(`missing ')'`, posStart, posEnd);
+      const errorParseResult = new ParseResult();
+      errorParseResult.failure(syntaxError);
+
+      const parseResult = new ParseResult();
+      const returnedNode: ASTNode = parseResult.tryRegister(errorParseResult);
+
+      expect(parseResult.getReverseToCount()).toEqual(errorParseResult.getAdvanceCount());
+      expect(returnedNode).toEqual(null);
+    });
+
+    it('should return result of calling register when passing in a normal parse result', () => {
+      const astNode: ASTNode = createASTNode(NodeTypes.NUMBER, NUMBER);
+      let nodeParseResult = new ParseResult();
+      nodeParseResult = nodeParseResult.success(astNode);
+
+      const parseResult = new ParseResult();
+      const returnedNode: ASTNode = parseResult.tryRegister(nodeParseResult);
+
+      expect(parseResult.getReverseToCount()).toEqual(0);
+      expect(returnedNode).toEqual(astNode);
+    });
+  });
+
   describe('registerAdvancement tests', () => {
     it('should increment advanceCount of parse result when registerAdvancement is called', () => {
       const parseResult = new ParseResult();

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -2368,7 +2368,7 @@ describe('Parser tests', () => {
     });
 
     describe('if, elif and else statement tests', () => {
-      it('should return correct AST for statement: if 1 > 2 then 1 + 1 end', () => {
+      it('should return correct AST for statement: if 1 > 2 then 1 + 1', () => {
         const posStartIf = new PositionTracker(0, 1, 1);
         const posStartNum1 = new PositionTracker(3, 1, 4);
         const posStartGThan = new PositionTracker(5, 1, 6);
@@ -2377,7 +2377,6 @@ describe('Parser tests', () => {
         const posStartNum3 = new PositionTracker(14, 1, 15);
         const posStartPlus = new PositionTracker(16, 1, 17);
         const posStartNum4 = new PositionTracker(18, 1, 19);
-        const posStartEnd = new PositionTracker(20, 1, 21);
         const posStartEof = new PositionTracker(23, 1, 24);
 
         const tokenList: Array<Token> = [
@@ -2389,7 +2388,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.NUMBER, posStartNum3, 1),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.NUMBER, posStartNum4, 1),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -2436,14 +2434,14 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it('should return correct AST for statement: if 1 > 2 then 1 + 1 elif x == y then 1 end', () => {
+      it('should return correct AST for statement: if 1 > 2 then 1 + 1 elif x == y then 1', () => {
         const posStartIf = new PositionTracker(0, 1, 1);
         const posStartNum1 = new PositionTracker(3, 1, 4);
         const posStartGThan = new PositionTracker(5, 1, 6);
@@ -2458,7 +2456,6 @@ describe('Parser tests', () => {
         const posStartVarY = new PositionTracker(30, 1, 31);
         const posStartThen2 = new PositionTracker(32, 1, 33);
         const posStartNum5 = new PositionTracker(37, 1, 38);
-        const posStartEnd = new PositionTracker(39, 1, 40);
         const posStartEof = new PositionTracker(42, 1, 43);
 
         const tokenList: Array<Token> = [
@@ -2476,7 +2473,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
           createToken(TokenTypes.KEYWORD, posStartThen2, 'then'),
           createToken(TokenTypes.NUMBER, posStartNum5, 1),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -2542,7 +2538,7 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 15; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 14; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -2550,7 +2546,7 @@ describe('Parser tests', () => {
       });
 
       it('should return correct AST for statement with many elifs and an else at the end', () => {
-        // Expression: if 1 > 2 then 1 + 1 elif x == y then 1 elif 1 < 2 then 2 elif x >= y then 0 else 1 + 1 end
+        // Expression: if 1 > 2 then 1 + 1 elif x == y then 1 elif 1 < 2 then 2 elif x >= y then 0 else 1 + 1
         const posStartIf = new PositionTracker(0, 1, 1);
         const posStartNum1 = new PositionTracker(3, 1, 4);
         const posStartGThan = new PositionTracker(5, 1, 6);
@@ -2581,7 +2577,6 @@ describe('Parser tests', () => {
         const posStartNum10 = new PositionTracker(81, 1, 82);
         const posStartPlus2 = new PositionTracker(83, 1, 84);
         const posStartNum11 = new PositionTracker(85, 1, 86);
-        const posStartEnd = new PositionTracker(87, 1, 88);
         const posStartEof = new PositionTracker(90, 1, 91);
 
         const tokenList: Array<Token> = [
@@ -2615,7 +2610,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.NUMBER, posStartNum10, 1),
           createToken(TokenTypes.PLUS, posStartPlus2),
           createToken(TokenTypes.NUMBER, posStartNum11, 1),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -2738,14 +2732,14 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 31; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 30; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error missing 'then' in parse result for expression: if 1 == 1 1 end`, () => {
+      it(`should return correct error missing 'then' in parse result for expression: if 1 == 1 1`, () => {
         const posStartIf = new PositionTracker(0, 1, 1);
         const posStartNum1 = new PositionTracker(3, 1, 4);
         const posStartEquality = new PositionTracker(5, 1, 6);
@@ -2781,7 +2775,7 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error missing 'then' in parse result for expression: if 1 == 1 then 1 elif 1 > 0 1 + 1 end`, () => {
+      it(`should return correct error missing 'then' in parse result for expression: if 1 == 1 then 1 elif 1 > 0 1 + 1`, () => {
         const posStartIf = new PositionTracker(0, 1, 1);
         const posStartNum1 = new PositionTracker(3, 1, 4);
         const posStartEquality = new PositionTracker(5, 1, 6);
@@ -2796,7 +2790,6 @@ describe('Parser tests', () => {
         const posEndNum6 = new PositionTracker(29, 1, 30);
         const posStartPlus = new PositionTracker(30, 1, 31);
         const posStartNum7 = new PositionTracker(32, 1, 33);
-        const posStartEnd = new PositionTracker(34, 1, 35);
         const posStartEof = new PositionTracker(37, 1, 38);
 
         const tokenList: Array<Token> = [
@@ -2813,7 +2806,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.NUMBER, posStartNum6, 1),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.NUMBER, posStartNum7, 1),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -2827,42 +2819,6 @@ describe('Parser tests', () => {
         expected.failure(error);
 
         for (let i = 0; i < 10; i++) { expected.registerAdvancement(); }
-
-        expect(parseResult.getNode()).toEqual(expected.getNode());
-        expect(parseResult.getError()).toEqual(expected.getError());
-        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
-      });
-
-      it(`should return correct error missing 'end' in parse result for expression: if 1 == 1 then 1`, () => {
-        const posStartIf = new PositionTracker(0, 1, 1);
-        const posStartNum1 = new PositionTracker(3, 1, 4);
-        const posStartEquality = new PositionTracker(5, 1, 6);
-        const posStartNum2 = new PositionTracker(8, 1, 9);
-        const posStartThen = new PositionTracker(10, 1, 11);
-        const posStartNum3 = new PositionTracker(15, 1, 16);
-        const posStartEof = new PositionTracker(16, 1, 17);
-        const posEndEof = new PositionTracker(17, 1, 18);
-
-        const tokenList: Array<Token> = [
-          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
-          createToken(TokenTypes.NUMBER, posStartNum1, 1),
-          createToken(TokenTypes.EQUALITY, posStartEquality),
-          createToken(TokenTypes.NUMBER, posStartNum2, 1),
-          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
-          createToken(TokenTypes.NUMBER, posStartNum3, 1),
-          createToken(TokenTypes.EOF, posStartEof)
-        ];
-
-        const parser = new Parser(tokenList);
-        const parseResult: ParseResult = parser.parse();
-
-        const error = new InvalidSyntaxError(`Expected 'end' keyword`, posStartEof,
-                                              posEndEof);
-
-        let expected = new ParseResult();
-        expected.failure(error);
-
-        for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -4121,7 +4077,7 @@ describe('Parser tests', () => {
     // Block code is having multiple lines inside a function or if/elif/else/for/while loops.
     describe('multi-lined code with no block code tests', () => {
       it('should create list of outputs for each line for a given multi-line code', () => {
-        // code: function add(x, y) begin x + y end\nif add(3, 2) > 2 then TRUE end\n"string"
+        // code: function add(x, y) begin x + y end\nif add(3, 2) > 2 then TRUE\n"string"
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
@@ -4146,7 +4102,6 @@ describe('Parser tests', () => {
         const posStartNumber3 = new PositionTracker(48, 2, 14);
         const posStartThen = new PositionTracker(50, 2, 16);
         const posStartTrue = new PositionTracker(55, 2, 21);
-        const posStartEnd2 = new PositionTracker(60, 2, 26);
         const posStartNewline2 = new PositionTracker(63, 2, 29);
         const posStartString = new PositionTracker(64, 3, 1);
         const posStartEof = new PositionTracker(72, 3, 9);
@@ -4176,7 +4131,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.NUMBER, posStartNumber3, 2),
           createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
           createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE'),
-          createToken(TokenTypes.KEYWORD, posStartEnd2, 'end'),
           createToken(TokenTypes.NEWLINE, posStartNewline2),
           createToken(TokenTypes.STRING, posStartString, 'string'),
           createToken(TokenTypes.EOF, posStartEof)
@@ -4263,7 +4217,7 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(listNode);
 
-        for (let i = 0; i < 27; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 26; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -4415,6 +4369,451 @@ describe('Parser tests', () => {
         expected.failure(error);
 
         for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+    });
+
+    describe('multi-lined code with block code tests', () => {
+      it('should produce correct AST for if statement with block code', () => {
+        // code: if 1 > 0 then\nx = 0\ny = 1\nend
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartGThan = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(7, 1, 8);
+        const posStartThen = new PositionTracker(9, 1, 10);
+        const posStartNewline1 = new PositionTracker(13, 1, 14);
+        const posStartVarX = new PositionTracker(14, 2, 1);
+        const posStartEquals1 = new PositionTracker(16, 2, 3);
+        const posStartNum3 = new PositionTracker(18, 2, 5);
+        const posStartNewline2 = new PositionTracker(19, 2, 6);
+        const posStartVarY = new PositionTracker(20, 3, 1);
+        const posStartEquals2 = new PositionTracker(22, 3, 3);
+        const posStartNum4 = new PositionTracker(24, 3, 5);
+        const posStartNewline3 = new PositionTracker(25, 3, 6);
+        const posStartEnd = new PositionTracker(26, 4, 1);
+        const posStartEof = new PositionTracker(29, 4, 4);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.G_THAN, posStartGThan),
+          createToken(TokenTypes.NUMBER, posStartNum2, 0),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.NUMBER, posStartNum3, 0),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.NUMBER, posStartNum4, 1),
+          createToken(TokenTypes.NEWLINE, posStartNewline3),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1),
+        }
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 0),
+        }
+        const compareNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.G_THAN, posStartGThan),
+          leftChild: numberNode1,
+          rightChild: numberNode2
+        };
+
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 0),
+        };
+        const varXAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          node: numberNode3
+        }
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 1),
+        };
+        const varYAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          node: numberNode4
+        }
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          elementNodes: [varXAssignNode, varYAssignNode]
+        };
+        const ifNode: ASTNode = {
+          nodeType: NodeTypes.IFSTATEMENT,
+          token: createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          cases: [[compareNode, listNode]],
+          elseCase: null
+        };
+
+        let expected = new ParseResult();
+        expected.success(ifNode);
+
+        for (let i = 0; i < 15; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+
+      it('should produce correct AST for if and else statements with block code', () => {
+        // code: if 1 < 0 then\nx = 0\ny = 1\nelse\nx = 100\nend
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartLThan = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(7, 1, 8);
+        const posStartThen = new PositionTracker(9, 1, 10);
+        const posStartNewline1 = new PositionTracker(13, 1, 14);
+        const posStartVarX = new PositionTracker(14, 2, 1);
+        const posStartEquals1 = new PositionTracker(16, 2, 3);
+        const posStartNum3 = new PositionTracker(18, 2, 5);
+        const posStartNewline2 = new PositionTracker(19, 2, 6);
+        const posStartVarY = new PositionTracker(20, 3, 1);
+        const posStartEquals2 = new PositionTracker(22, 3, 3);
+        const posStartNum4 = new PositionTracker(24, 3, 5);
+        const posStartNewline3 = new PositionTracker(25, 3, 6);
+        const posStartElse = new PositionTracker(26, 4, 1);
+        const posStartNewline4 = new PositionTracker(30, 4, 5);
+        const posStartVarX2 = new PositionTracker(31, 5, 1);
+        const posStartEquals3 = new PositionTracker(33, 5, 3);
+        const posStartNum5 = new PositionTracker(35, 5, 5);
+        const posStartNewline5 = new PositionTracker(38, 5, 8);
+        const posStartEnd = new PositionTracker(39, 6, 1);
+        const posStartEof = new PositionTracker(42, 6, 4);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.L_THAN, posStartLThan),
+          createToken(TokenTypes.NUMBER, posStartNum2, 0),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.NUMBER, posStartNum3, 0),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.NUMBER, posStartNum4, 1),
+          createToken(TokenTypes.NEWLINE, posStartNewline3),
+          createToken(TokenTypes.KEYWORD, posStartElse, 'else'),
+          createToken(TokenTypes.NEWLINE, posStartNewline4),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals3),
+          createToken(TokenTypes.NUMBER, posStartNum5, 100),
+          createToken(TokenTypes.NEWLINE, posStartNewline5),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        }
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 0)
+        }
+        const compareNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.L_THAN, posStartLThan),
+          leftChild: numberNode1,
+          rightChild: numberNode2,
+        };
+
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 0)
+        };
+        const varXAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          node: numberNode3
+        };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 1)
+        };
+        const varYAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          node: numberNode4
+        };
+        const ifListNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          elementNodes: [varXAssignNode, varYAssignNode]
+        };
+
+        const numberNode5: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum5, 100)
+        };
+        const varX2AssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          node: numberNode5
+        };
+        const elseListNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          elementNodes: [varX2AssignNode]
+        };
+        const ifNode: ASTNode = {
+          nodeType: NodeTypes.IFSTATEMENT,
+          token: createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          cases: [[compareNode, ifListNode]],
+          elseCase: elseListNode
+        };
+
+        let expected = new ParseResult();
+        expected.success(ifNode);
+
+        for (let i = 0; i < 21; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+
+      it('should produce correct AST for if, elif and else statements with block code', () => {
+        // code: if 1 < 0 then\nx = 0\ny = 1\nelif 2 < 3 then\n1\nelse\nx = 100\nend
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartLThan = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(7, 1, 8);
+        const posStartThen = new PositionTracker(9, 1, 10);
+        const posStartNewline1 = new PositionTracker(13, 1, 14);
+        const posStartVarX = new PositionTracker(14, 2, 1);
+        const posStartEquals1 = new PositionTracker(16, 2, 3);
+        const posStartNum3 = new PositionTracker(18, 2, 5);
+        const posStartNewline2 = new PositionTracker(19, 2, 6);
+        const posStartVarY = new PositionTracker(20, 3, 1);
+        const posStartEquals2 = new PositionTracker(22, 3, 3);
+        const posStartNum4 = new PositionTracker(24, 3, 5);
+        const posStartNewline3 = new PositionTracker(25, 3, 6);
+        const posStartElif = new PositionTracker(26, 4, 1);
+        const posStartNum5 = new PositionTracker(31, 4, 6);
+        const posStartLThan2 = new PositionTracker(33, 4, 8);
+        const posStartNum6 = new PositionTracker(35, 4, 10);
+        const posStartThen2 = new PositionTracker(37, 4, 12);
+        const posStartNewline4 = new PositionTracker(41, 4, 16);
+        const posStartNum7 = new PositionTracker(42, 5, 1);
+        const posStartNewline5 = new PositionTracker(43, 5, 2);
+        const posStartElse = new PositionTracker(44, 6, 1);
+        const posStartNewline6 = new PositionTracker(48, 6, 5);
+        const posStartVarX2 = new PositionTracker(49, 7, 1);
+        const posStartEquals3 = new PositionTracker(51, 7, 3);
+        const posStartNum8 = new PositionTracker(53, 7, 5);
+        const posStartNewline7 = new PositionTracker(56, 7, 8);
+        const posStartEnd = new PositionTracker(57, 8, 1);
+        const posStartEof = new PositionTracker(60, 8, 4);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.L_THAN, posStartLThan),
+          createToken(TokenTypes.NUMBER, posStartNum2, 0),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.NUMBER, posStartNum3, 0),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.NUMBER, posStartNum4, 1),
+          createToken(TokenTypes.NEWLINE, posStartNewline3),
+          createToken(TokenTypes.KEYWORD, posStartElif, 'elif'),
+          createToken(TokenTypes.NUMBER, posStartNum5, 2),
+          createToken(TokenTypes.L_THAN, posStartLThan2),
+          createToken(TokenTypes.NUMBER, posStartNum6, 3),
+          createToken(TokenTypes.KEYWORD, posStartThen2, 'then'),
+          createToken(TokenTypes.NEWLINE, posStartNewline4),
+          createToken(TokenTypes.NUMBER, posStartNum7, 1),
+          createToken(TokenTypes.NEWLINE, posStartNewline5),
+          createToken(TokenTypes.KEYWORD, posStartElse, 'else'),
+          createToken(TokenTypes.NEWLINE, posStartNewline6),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals3),
+          createToken(TokenTypes.NUMBER, posStartNum8, 100),
+          createToken(TokenTypes.NEWLINE, posStartNewline7),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode5: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum5, 2)
+        }
+        const numberNode6: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum6, 3)
+        }
+        const elifCompareNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.L_THAN, posStartLThan2),
+          leftChild: numberNode5,
+          rightChild: numberNode6,
+        };
+
+        const numberNode7: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum7, 1)
+        };
+        const elifListNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.NUMBER, posStartNum7, 1),
+          elementNodes: [numberNode7]
+        };
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        }
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 0)
+        }
+        const ifCompareNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.L_THAN, posStartLThan),
+          leftChild: numberNode1,
+          rightChild: numberNode2,
+        };
+
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 0)
+        };
+        const varXAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          node: numberNode3
+        };
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 1)
+        };
+        const varYAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          node: numberNode4
+        };
+        const ifListNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          elementNodes: [varXAssignNode, varYAssignNode]
+        };
+
+        const numberNode8: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum8, 100)
+        };
+        const varX2AssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          node: numberNode8
+        };
+        const elseListNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          elementNodes: [varX2AssignNode]
+        };
+        const ifNode: ASTNode = {
+          nodeType: NodeTypes.IFSTATEMENT,
+          token: createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          cases: [[ifCompareNode, ifListNode], [elifCompareNode, elifListNode]],
+          elseCase: elseListNode
+        };
+
+        let expected = new ParseResult();
+        expected.success(ifNode);
+
+        for (let i = 0; i < 29; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+
+      it(`should produce error for if and else statements with block code and no 'end' keyword`, () => {
+        // code: if 1 < 0 then\nx = 0\ny = 1\nelse\n100\n
+        const posStartIf = new PositionTracker(0, 1, 1);
+        const posStartNum1 = new PositionTracker(3, 1, 4);
+        const posStartLThan = new PositionTracker(5, 1, 6);
+        const posStartNum2 = new PositionTracker(7, 1, 8);
+        const posStartThen = new PositionTracker(9, 1, 10);
+        const posStartNewline1 = new PositionTracker(13, 1, 14);
+        const posStartVarX = new PositionTracker(14, 2, 1);
+        const posStartEquals1 = new PositionTracker(16, 2, 3);
+        const posStartNum3 = new PositionTracker(18, 2, 5);
+        const posStartNewline2 = new PositionTracker(19, 2, 6);
+        const posStartVarY = new PositionTracker(20, 3, 1);
+        const posStartEquals2 = new PositionTracker(22, 3, 3);
+        const posStartNum4 = new PositionTracker(24, 3, 5);
+        const posStartNewline3 = new PositionTracker(25, 3, 6);
+        const posStartElse = new PositionTracker(26, 4, 1);
+        const posStartNewline4 = new PositionTracker(30, 4, 5);
+        const posStartNum5 = new PositionTracker(35, 5, 5);
+        const posStartNewline5 = new PositionTracker(38, 5, 8);
+        const posStartEof = new PositionTracker(39, 6, 1);
+        const posEndEof = new PositionTracker(40, 6, 2);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.L_THAN, posStartLThan),
+          createToken(TokenTypes.NUMBER, posStartNum2, 0),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.NUMBER, posStartNum3, 0),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.NUMBER, posStartNum4, 1),
+          createToken(TokenTypes.NEWLINE, posStartNewline3),
+          createToken(TokenTypes.KEYWORD, posStartElse, 'else'),
+          createToken(TokenTypes.NEWLINE, posStartNewline4),
+          createToken(TokenTypes.NUMBER, posStartNum5, 100),
+          createToken(TokenTypes.NEWLINE, posStartNewline5),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const error = new InvalidSyntaxError(`Expected 'end' keyword`, posStartEof, posEndEof);
+
+        let expected = new ParseResult();
+        expected.failure(error);
+
+        for (let i = 0; i < 18; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -2953,20 +2953,18 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it('should return correct AST for statement: while TRUE loop 1 end', () => {
+      it('should return correct AST for statement: while TRUE loop 1', () => {
         const posStartWhile = new PositionTracker(0, 1, 1);
         const posStartTrue = new PositionTracker(6, 1, 7);
         const posStartLoop = new PositionTracker(11, 1, 12);
         const posStartNum = new PositionTracker(16, 1, 17);
-        const posStartEnd = new PositionTracker(18, 1, 19);
-        const posStartEof = new PositionTracker(21, 1, 22);
+        const posStartEof = new PositionTracker(17, 1, 18);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartWhile, 'while'),
           createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE'),
           createToken(TokenTypes.KEYWORD, posStartLoop, 'loop'),
           createToken(TokenTypes.NUMBER, posStartNum, 1),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -2992,7 +2990,7 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 5; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -3075,19 +3073,17 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error missing 'loop' in parse result for expression: while TRUE 1 end`, () => {
+      it(`should return correct error missing 'loop' in parse result for expression: while TRUE 1`, () => {
         const posStartWhile = new PositionTracker(0, 1, 1);
         const posStartTrue = new PositionTracker(6, 1, 7);
         const posStartNum = new PositionTracker(11, 1, 12);
         const posEndNum = new PositionTracker(12, 1, 13);
-        const posStartEnd = new PositionTracker(13, 1, 14);
-        const posStartEof = new PositionTracker(16, 1, 17);
+        const posStartEof = new PositionTracker(13, 1, 14);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartWhile, 'while'),
           createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE'),
           createToken(TokenTypes.NUMBER, posStartNum, 1),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3101,38 +3097,6 @@ describe('Parser tests', () => {
         expected.failure(error);
 
         for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
-
-        expect(parseResult.getNode()).toEqual(expected.getNode());
-        expect(parseResult.getError()).toEqual(expected.getError());
-        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
-      });
-
-      it(`should return correct error missing 'end' in parse result for expression: while TRUE loop 1`, () => {
-        const posStartWhile = new PositionTracker(0, 1, 1);
-        const posStartTrue = new PositionTracker(6, 1, 7);
-        const posStartLoop = new PositionTracker(11, 1, 12);
-        const posStartNum = new PositionTracker(16, 1, 17);
-        const posStartEof = new PositionTracker(17, 1, 18);
-        const posEndEof = new PositionTracker(18, 1, 19);
-
-        const tokenList: Array<Token> = [
-          createToken(TokenTypes.KEYWORD, posStartWhile, 'while'),
-          createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE'),
-          createToken(TokenTypes.KEYWORD, posStartLoop, 'loop'),
-          createToken(TokenTypes.NUMBER, posStartNum, 1),
-          createToken(TokenTypes.EOF, posStartEof)
-        ];
-
-        const parser = new Parser(tokenList);
-        const parseResult: ParseResult = parser.parse();
-
-        const error = new InvalidSyntaxError(`Expected 'end' keyword`, posStartEof,
-                                              posEndEof);
-
-        let expected = new ParseResult();
-        expected.failure(error);
-
-        for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -4847,6 +4811,141 @@ describe('Parser tests', () => {
         expected.success(forNode);
 
         for (let i = 0; i < 13; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+
+      it('should return correct AST for block statements inside a while loop', () => {
+        // code: x = 0\nfinal = 2\nwhile x < final loop\nx = x + 1\nend
+        const posStartVarX1 = new PositionTracker(0, 1, 1);
+        const posStartEquals1 = new PositionTracker(2, 1, 3);
+        const posStartNum1 = new PositionTracker(4, 1, 5);
+        const posStartNewline1 = new PositionTracker(5, 1, 6);
+        const posStartVarFinal1 = new PositionTracker(6, 2, 1);
+        const posStartEquals2 = new PositionTracker(12, 2, 7);
+        const posStartNum2 = new PositionTracker(14, 2, 9);
+        const posStartNewline2 = new PositionTracker(15, 2, 16);
+        const posStartWhile = new PositionTracker(16, 3, 1);
+        const posStartVarX2 = new PositionTracker(22, 3, 7);
+        const posStartLThan = new PositionTracker(24, 3, 9);
+        const posStartVarFinal2 = new PositionTracker(26, 3, 11);
+        const posStartLoop = new PositionTracker(32, 3, 17);
+        const posStartNewline3 = new PositionTracker(36, 3, 21);
+        const posStartVarX3 = new PositionTracker(37, 4, 1);
+        const posStartEquals3 = new PositionTracker(39, 4, 3);
+        const posStartVarX4 = new PositionTracker(41, 4, 5);
+        const posStartPlus = new PositionTracker(43, 4, 7);
+        const posStartNum3 = new PositionTracker(45, 4, 9);
+        const posStartNewline4 = new PositionTracker(46, 4, 10);
+        const posStartEnd = new PositionTracker(47, 5, 1);
+        const posStartEof = new PositionTracker(50, 5, 4);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartVarX1, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.NUMBER, posStartNum1, 0),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarFinal1, 'final'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.NUMBER, posStartNum2, 2),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.KEYWORD, posStartWhile, 'while'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.L_THAN, posStartLThan),
+          createToken(TokenTypes.IDENTIFIER, posStartVarFinal2, 'final'),
+          createToken(TokenTypes.KEYWORD, posStartLoop, 'loop'),
+          createToken(TokenTypes.NEWLINE, posStartNewline3),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX3, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals3),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX4, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.NUMBER, posStartNum3, 1),
+          createToken(TokenTypes.NEWLINE, posStartNewline4),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 0)
+        };
+        const varXAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX1, 'x'),
+          node: numberNode1
+        };
+
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2)
+        };
+        const varFinalAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarFinal1, 'final'),
+          node: numberNode2
+        };
+
+        const varXAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x')
+        };
+        const varFinalAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarFinal2, 'final')
+        };
+        const compareNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.L_THAN, posStartLThan),
+          leftChild: varXAccessNode,
+          rightChild: varFinalAccessNode
+        };
+
+        const varXAccessNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX4, 'x')
+        };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 1)
+        };
+        const addNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus),
+          leftChild: varXAccessNode2,
+          rightChild: numberNode3
+        };
+        const varXAssignNode2: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX3, 'x'),
+          node: addNode
+        };
+        const bodyNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX3, 'x'),
+          elementNodes: [varXAssignNode2]
+        };
+        const whileNode: ASTNode = {
+          nodeType: NodeTypes.WHILELOOP,
+          token: createToken(TokenTypes.KEYWORD, posStartWhile, 'while'),
+          conditionNode: compareNode,
+          bodyNode: bodyNode
+        };
+
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX1, 'x'),
+          elementNodes: [varXAssignNode, varFinalAssignNode, whileNode]
+        };
+
+        let expected = new ParseResult();
+        expected.success(listNode);
+
+        for (let i = 0; i < 21; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -2827,7 +2827,7 @@ describe('Parser tests', () => {
     });
 
     describe('for/while loop tests', () => {
-      it('should return correct AST for statement: for x = 1 to 10 loop 10 end', () => {
+      it('should return correct AST for statement: for x = 1 to 10 loop 10', () => {
         const posStartFor = new PositionTracker(0, 1, 1);
         const posStartVarX = new PositionTracker(4, 1, 5);
         const posStartEquals = new PositionTracker(6, 1, 7);
@@ -2836,8 +2836,7 @@ describe('Parser tests', () => {
         const posStartNum2 = new PositionTracker(13, 1, 14);
         const posStartLoop = new PositionTracker(16, 1, 17);
         const posStartNum3 = new PositionTracker(21, 1, 22);
-        const posStartEnd = new PositionTracker(24, 1, 25);
-        const posStartEof = new PositionTracker(25, 1, 26);
+        const posStartEof = new PositionTracker(23, 1, 24);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFor, 'for'),
@@ -2848,7 +2847,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.NUMBER, posStartNum2, 10),
           createToken(TokenTypes.KEYWORD, posStartLoop, 'loop'),
           createToken(TokenTypes.NUMBER, posStartNum3, 10),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -2881,14 +2879,14 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it('should return correct AST for statement: for x = 1 to 10 step 2 loop 10 end', () => {
+      it('should return correct AST for statement: for x = 1 to 10 step 2 loop 10', () => {
         const posStartFor = new PositionTracker(0, 1, 1);
         const posStartVarX = new PositionTracker(4, 1, 5);
         const posStartEquals = new PositionTracker(6, 1, 7);
@@ -2899,8 +2897,7 @@ describe('Parser tests', () => {
         const posStartNum3 = new PositionTracker(21, 1, 22);
         const posStartLoop = new PositionTracker(23, 1, 24);
         const posStartNum4 = new PositionTracker(28, 1, 29);
-        const posStartEnd = new PositionTracker(31, 1, 32);
-        const posStartEof = new PositionTracker(34, 1, 35);
+        const posStartEof = new PositionTracker(30, 1, 31);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFor, 'for'),
@@ -2913,7 +2910,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.NUMBER, posStartNum3, 2),
           createToken(TokenTypes.KEYWORD, posStartLoop, 'loop'),
           createToken(TokenTypes.NUMBER, posStartNum4, 10),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -2950,7 +2946,7 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 10; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -3003,7 +2999,7 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error missing 'to' in parse result for expression: for x = 1 10 loop 10 end`, () => {
+      it(`should return correct error missing 'to' in parse result for expression: for x = 1 10 loop 10`, () => {
         const posStartFor = new PositionTracker(0, 1, 1);
         const posStartVarX = new PositionTracker(4, 1, 5);
         const posStartEquals = new PositionTracker(6, 1, 7);
@@ -3012,8 +3008,7 @@ describe('Parser tests', () => {
         const posEndNum2 = new PositionTracker(11, 1, 12);
         const posStartLoop = new PositionTracker(13, 1, 14);
         const posStartNum3 = new PositionTracker(18, 1, 19);
-        const posStartEnd = new PositionTracker(21, 1, 22);
-        const posStartEof = new PositionTracker(24, 1, 25);
+        const posStartEof = new PositionTracker(20, 1, 21);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFor, 'for'),
@@ -3023,7 +3018,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.NUMBER, posStartNum2, 10),
           createToken(TokenTypes.KEYWORD, posStartLoop, 'loop'),
           createToken(TokenTypes.NUMBER, posStartNum3, 10),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3043,17 +3037,16 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error missing 'loop' in parse result for expression: for x = 1 to 10 10 end`, () => {
+      it(`should return correct error missing 'loop' in parse result for expression: for x = 1 to 10 10`, () => {
         const posStartFor = new PositionTracker(0, 1, 1);
         const posStartVarX = new PositionTracker(4, 1, 5);
         const posStartEquals = new PositionTracker(6, 1, 7);
         const posStartNum1 = new PositionTracker(8, 1, 9);
         const posStartTo = new PositionTracker(10, 1, 11);
         const posStartNum2 = new PositionTracker(13, 1, 14);
-        const posStartNum3 = new PositionTracker(15, 1, 16);
-        const posEndNum3 = new PositionTracker(16, 1, 17);
-        const posStartEnd = new PositionTracker(18, 1, 19);
-        const posStartEof = new PositionTracker(21, 1, 22);
+        const posStartNum3 = new PositionTracker(16, 1, 17);
+        const posEndNum3 = new PositionTracker(17, 1, 18);
+        const posStartEof = new PositionTracker(18, 1, 19);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFor, 'for'),
@@ -3063,7 +3056,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.KEYWORD, posStartTo, 'to'),
           createToken(TokenTypes.NUMBER, posStartNum2, 10),
           createToken(TokenTypes.NUMBER, posStartNum3, 10),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3077,46 +3069,6 @@ describe('Parser tests', () => {
         expected.failure(error);
 
         for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
-
-        expect(parseResult.getNode()).toEqual(expected.getNode());
-        expect(parseResult.getError()).toEqual(expected.getError());
-        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
-      });
-
-      it(`should return correct error missing 'end' in parse result for expression: for x = 1 to 10 loop 10`, () => {
-        const posStartFor = new PositionTracker(0, 1, 1);
-        const posStartVarX = new PositionTracker(4, 1, 5);
-        const posStartEquals = new PositionTracker(6, 1, 7);
-        const posStartNum1 = new PositionTracker(8, 1, 9);
-        const posStartTo = new PositionTracker(10, 1, 11);
-        const posStartNum2 = new PositionTracker(13, 1, 14);
-        const posStartLoop = new PositionTracker(16, 1, 17);
-        const posStartNum3 = new PositionTracker(21, 1, 22);
-        const posStartEof = new PositionTracker(23, 1, 24);
-        const posEndEof = new PositionTracker(24, 1, 25);
-
-        const tokenList: Array<Token> = [
-          createToken(TokenTypes.KEYWORD, posStartFor, 'for'),
-          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
-          createToken(TokenTypes.EQUALS, posStartEquals),
-          createToken(TokenTypes.NUMBER, posStartNum1, 1),
-          createToken(TokenTypes.KEYWORD, posStartTo, 'to'),
-          createToken(TokenTypes.NUMBER, posStartNum2, 10),
-          createToken(TokenTypes.KEYWORD, posStartLoop, 'loop'),
-          createToken(TokenTypes.NUMBER, posStartNum3, 10),
-          createToken(TokenTypes.EOF, posStartEof)
-        ];
-
-        const parser = new Parser(tokenList);
-        const parseResult: ParseResult = parser.parse();
-
-        const error = new InvalidSyntaxError(`Expected 'end' keyword`, posStartEof,
-                                              posEndEof);
-
-        let expected = new ParseResult();
-        expected.failure(error);
-
-        for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -4814,6 +4766,87 @@ describe('Parser tests', () => {
         expected.failure(error);
 
         for (let i = 0; i < 18; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+
+      it('should return correct AST for block statements inside a for loop', () => {
+        // code: for i = 1 to 5 loop\nx = i\nend
+        const posStartFor = new PositionTracker(0, 1, 1);
+        const posStartI = new PositionTracker(4, 1, 5);
+        const posStartEquals1 = new PositionTracker(6, 1, 7);
+        const posStartNum1 = new PositionTracker(8, 1, 9);
+        const posStartTo = new PositionTracker(10, 1, 11);
+        const posStartNum2 = new PositionTracker(13, 1, 14);
+        const posStartLoop = new PositionTracker(15, 1, 16);
+        const posStartNewline1 = new PositionTracker(19, 1, 20);
+        const posStartVarX = new PositionTracker(20, 2, 1);
+        const posStartEquals2 = new PositionTracker(22, 2, 3);
+        const posStartVarI = new PositionTracker(24, 2, 5);
+        const posStartNewline2 = new PositionTracker(25, 2, 6);
+        const posStartEnd = new PositionTracker(26, 3, 1);
+        const posStartEof = new PositionTracker(29, 3, 4);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFor, 'for'),
+          createToken(TokenTypes.IDENTIFIER, posStartI, 'i'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.KEYWORD, posStartTo, 'to'),
+          createToken(TokenTypes.NUMBER, posStartNum2, 5),
+          createToken(TokenTypes.KEYWORD, posStartLoop, 'loop'),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarI, 'i'),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const varIAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarI, 'i'),
+        }
+        const varXAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          node: varIAccessNode
+        };
+
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          elementNodes: [varXAssignNode]
+        };
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 5)
+        };
+        const forNode: ASTNode = {
+          nodeType: NodeTypes.FORLOOP,
+          token: createToken(TokenTypes.KEYWORD, posStartFor, 'for'),
+          varNameToken: createToken(TokenTypes.IDENTIFIER, posStartI, 'i'),
+          startValueNode: numberNode1,
+          endValueNode: numberNode2,
+          stepValueNode: null,
+          bodyNode: listNode
+        };
+
+        let expected = new ParseResult();
+        expected.success(forNode);
+
+        for (let i = 0; i < 13; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -30,7 +30,9 @@ describe('Parser tests', () => {
 
         expected.registerAdvancement();
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return a single number node result with one decimal number in token list', () => {
@@ -52,7 +54,9 @@ describe('Parser tests', () => {
 
         expected.registerAdvancement();
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for unary operation expression: -1', () => {
@@ -83,7 +87,9 @@ describe('Parser tests', () => {
         expected.registerAdvancement();
         expected.registerAdvancement();
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for unary operation expression: +1', () => {
@@ -114,7 +120,9 @@ describe('Parser tests', () => {
         expected.registerAdvancement();
         expected.registerAdvancement();
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for binary operation expression: 3 + 4', () => {
@@ -153,7 +161,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for binary operation expression: 10 - 9', () => {
@@ -192,7 +202,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for binary operation expression: 8 * 4', () => {
@@ -231,7 +243,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for binary operation expression: 8 / 4', () => {
@@ -270,7 +284,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for binary operation expression: 3 ^ 2', () => {
@@ -309,7 +325,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for expression: ((1 + 2) * (4 - 1))', () => {
@@ -390,7 +408,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 13; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for expression: (1 + 2) / 3', () => {
@@ -449,7 +469,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for expression: 1 + 2 ^ 3 - 4', () => {
@@ -518,7 +540,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for expression: -2 ^ 3', () => {
@@ -565,7 +589,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for expression: (1 + 2) ^ 3 - 4', () => {
@@ -638,7 +664,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for expression: -((1 + 2) * (4 - 1))', () => {
@@ -727,7 +755,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 14; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return parse result with correct missing operation error for expression: 10 200', () => {
@@ -748,17 +778,24 @@ describe('Parser tests', () => {
           nodeType: NodeTypes.NUMBER,
           token: createToken(TokenTypes.NUMBER, posStartNum1, 10)
         };
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 10),
+          elementNodes: [numberNode1]
+        };
         const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', ` +
                                              `'>', '<=', '>=', 'AND' or 'OR'`, posStartNum2,
                                               posStartEof);
 
         let expected = new ParseResult();
-        expected.success(numberNode1);
+        expected.success(listNode);
         expected.failure(error);
 
         expected.registerAdvancement();
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return parse result with correct missing operation error for expression: (1 + 2) 4', () => {
@@ -797,18 +834,24 @@ describe('Parser tests', () => {
           leftChild: numberNode1,
           rightChild: numberNode2
         };
-
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          elementNodes: [binaryExp]
+        };
         const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', ` +
                                              `'>', '<=', '>=', 'AND' or 'OR'`, posStartNum3,
                                               posStartEof);
 
         let expected = new ParseResult();
-        expected.success(binaryExp);
+        expected.success(listNode);
         expected.failure(error);
 
         for (let i = 0; i < 5; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return parse result with correct 'missing ')'' error for expression: ((1 + 2) - 1`, () => {
@@ -845,7 +888,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
 
@@ -872,7 +917,9 @@ describe('Parser tests', () => {
 
         expected.registerAdvancement();
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
 
@@ -902,7 +949,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: [1, 2, 3]', () => {
@@ -952,7 +1001,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: [1, 2, "string"]', () => {
@@ -1002,7 +1053,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: [[]]', () => {
@@ -1039,7 +1092,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: [[1, 2], [1, 3]]', () => {
@@ -1117,7 +1172,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 13; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct error in parse result for expression: [1 2]', () => {
@@ -1146,7 +1203,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct error in parse result for expression: [1, 2, 3', () => {
@@ -1180,7 +1239,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
 
@@ -1216,7 +1277,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: variable = (1 * 3) ^ 2', () => {
@@ -1284,7 +1347,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: variable = -((1 * 3) ^ 2)', () => {
@@ -1364,7 +1429,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 12; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: 1 + (x = 10) * 2', () => {
@@ -1432,7 +1499,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: x = "some string"', () => {
@@ -1467,7 +1536,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct error in parse result for expression: x =', () => {
@@ -1493,7 +1564,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct error in parse result for expression: 1 + x = 10 * 2', () => {
@@ -1535,18 +1608,24 @@ describe('Parser tests', () => {
           leftChild: numberNode1,
           rightChild: varAccessNode
         };
-
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          elementNodes: [currentAst]
+        };
         const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', ` +
                                              `'>', '<=', '>=', 'AND' or 'OR'`, posStartEquals,
                                              posEndEquals);
 
         let expected = new ParseResult();
-        expected.success(currentAst);
+        expected.success(listNode);
         expected.failure(error);
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
 
@@ -1625,7 +1704,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: x = y', () => {
@@ -1659,7 +1740,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: -variable', () => {
@@ -1691,7 +1774,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct error in parse result for expression: x y', () => {
@@ -1712,17 +1797,24 @@ describe('Parser tests', () => {
           nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartVariable1, 'x')
         };
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVariable1, 'x'),
+          elementNodes: [xVarAccessNode]
+        };
         const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', ` +
                                              `'>', '<=', '>=', 'AND' or 'OR'`, posStartVariable2,
                                              posStartEof);
 
         let expected = new ParseResult();
-        expected.success(xVarAccessNode);
+        expected.success(listNode);
         expected.failure(error);
 
         expected.registerAdvancement();
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
 
@@ -1763,7 +1855,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: 10 > 1', () => {
@@ -1802,7 +1896,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: 1 < 2', () => {
@@ -1841,7 +1937,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: 1 >= 1', () => {
@@ -1880,7 +1978,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: 1 <= 1', () => {
@@ -1919,7 +2019,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: TRUE AND FALSE', () => {
@@ -1958,7 +2060,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: TRUE OR FALSE', () => {
@@ -1997,7 +2101,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: NOT TRUE AND FALSE', () => {
@@ -2043,7 +2149,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: var = NOT TRUE AND ((10 > 1) OR (5 < x))', () => {
@@ -2157,7 +2265,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 18; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement (not keywords): true and false', () => {
@@ -2181,17 +2291,24 @@ describe('Parser tests', () => {
           nodeType: NodeTypes.VARACCESS,
           token: createToken(TokenTypes.IDENTIFIER, posStartTrue, 'true')
         };
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartTrue, 'true'),
+          elementNodes: [trueNode]
+        };
         const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', ` +
                                              `'>', '<=', '>=', 'AND' or 'OR'`, posStartAnd,
                                              posEndAnd);
 
         let expected = new ParseResult();
-        expected.success(trueNode);
+        expected.success(listNode);
         expected.failure(error);
 
         expected.registerAdvancement();
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: TRUE AND (var = FALSE)', () => {
@@ -2244,7 +2361,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
 
@@ -2319,7 +2438,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: if 1 > 2 then 1 + 1 elif x == y then 1 end', () => {
@@ -2423,7 +2544,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 15; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement with many elifs and an else at the end', () => {
@@ -2617,7 +2740,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 31; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'then' in parse result for expression: if 1 == 1 1 end`, () => {
@@ -2651,7 +2776,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'then' in parse result for expression: if 1 == 1 then 1 elif 1 > 0 1 + 1 end`, () => {
@@ -2701,7 +2828,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 10; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'end' in parse result for expression: if 1 == 1 then 1`, () => {
@@ -2735,7 +2864,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
 
@@ -2796,7 +2927,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: for x = 1 to 10 step 2 loop 10 end', () => {
@@ -2863,7 +2996,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: while TRUE loop 1 end', () => {
@@ -2907,7 +3042,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 5; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'to' in parse result for expression: for x = 1 10 loop 10 end`, () => {
@@ -2945,7 +3082,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'loop' in parse result for expression: for x = 1 to 10 10 end`, () => {
@@ -2983,7 +3122,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'end' in parse result for expression: for x = 1 to 10 loop 10`, () => {
@@ -3021,7 +3162,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'loop' in parse result for expression: while TRUE 1 end`, () => {
@@ -3051,7 +3194,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'end' in parse result for expression: while TRUE loop 1`, () => {
@@ -3081,7 +3226,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
 
@@ -3127,7 +3274,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: function add(x, y) begin x + y end', () => {
@@ -3192,7 +3341,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 12; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       // // Anonymous function support.
@@ -3256,7 +3407,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: func = function (x, y) begin x + y end', () => {
@@ -3329,7 +3482,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 13; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: func(x, y, z)', () => {
@@ -3386,7 +3541,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: func(10, 1, 2)', () => {
@@ -3443,7 +3600,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: func()', () => {
@@ -3478,7 +3637,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it('should return correct AST for statement: sum = add(x, y)', () => {
@@ -3537,7 +3698,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error expected '(' in parse result for expression: function add x, y) begin x + y end`, () => {
@@ -3580,7 +3743,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 2; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing ',' or ')' in parse result for expression: function add(x y) begin x + y end`, () => {
@@ -3623,7 +3788,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing ',' or ')' in parse result for expression: function add(x, y begin x + y end`, () => {
@@ -3667,7 +3834,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error 'Expected identifier' in parse result for expression: function add(x, ) begin x + y end`, () => {
@@ -3711,7 +3880,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 5; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'begin' in parse result for expression: function add(x, y) x + y end`, () => {
@@ -3755,7 +3926,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct expression error in parse result for expression: function add(x, y) begin end`, () => {
@@ -3795,7 +3968,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing 'end' in parse result for expression: function add(x, y) begin x + y`, () => {
@@ -3838,7 +4013,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error 'Expected identifier' in parse result for expression: add(x, )`, () => {
@@ -3869,7 +4046,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 4; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing ',' or ')' in parse result for expression: add(x y)`, () => {
@@ -3900,7 +4079,9 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 3; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
       it(`should return correct error missing ',' or ')' in parse result for expression: add(x, y`, () => {
@@ -3931,7 +4112,313 @@ describe('Parser tests', () => {
 
         for (let i = 0; i < 5; i++) { expected.registerAdvancement(); }
 
-        expect(parseResult).toEqual(expected);
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+    });
+
+    // Block code is having multiple lines inside a function or if/elif/else/for/while loops.
+    describe('multi-lined code with no block code tests', () => {
+      it('should create list of outputs for each line for a given multi-line code', () => {
+        // code: function add(x, y) begin x + y end\nif add(3, 2) > 2 then TRUE end\n"string"
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack = new PositionTracker(12, 1, 13);
+        const posStartVarX = new PositionTracker(13, 1, 14);
+        const posStartComma = new PositionTracker(14, 1, 15);
+        const posStartVarY = new PositionTracker(16, 1, 17);
+        const posStartRightBrack = new PositionTracker(17, 1, 18);
+        const posStartBegin = new PositionTracker(19, 1, 20);
+        const posStartVarX2 = new PositionTracker(25, 1, 26);
+        const posStartPlus = new PositionTracker(27, 1, 28);
+        const posStartVarY2 = new PositionTracker(29, 1, 30);
+        const posStartEnd = new PositionTracker(31, 1, 32);
+        const posStartNewline1 = new PositionTracker(34, 1, 35);
+        const posStartIf = new PositionTracker(35, 2, 1);
+        const posStartFuncCall = new PositionTracker(38, 2, 4);
+        const posStartLeftBrack2 = new PositionTracker(39, 2, 5);
+        const posStartNumber1 = new PositionTracker(40, 2, 6);
+        const posStartComma2 = new PositionTracker(41, 2, 7);
+        const posStartNumber2 = new PositionTracker(43, 2, 9);
+        const posStartRightBrack2 = new PositionTracker(44, 2, 10);
+        const posStartGThan = new PositionTracker(46, 2, 12);
+        const posStartNumber3 = new PositionTracker(48, 2, 14);
+        const posStartThen = new PositionTracker(50, 2, 16);
+        const posStartTrue = new PositionTracker(55, 2, 21);
+        const posStartEnd2 = new PositionTracker(60, 2, 26);
+        const posStartNewline2 = new PositionTracker(63, 2, 29);
+        const posStartString = new PositionTracker(64, 3, 1);
+        const posStartEof = new PositionTracker(72, 3, 9);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
+          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.PLUS, posStartPlus),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncCall, 'add'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack2),
+          createToken(TokenTypes.NUMBER, posStartNumber1, 3),
+          createToken(TokenTypes.COMMA, posStartComma2),
+          createToken(TokenTypes.NUMBER, posStartNumber2, 2),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack2),
+          createToken(TokenTypes.G_THAN, posStartGThan),
+          createToken(TokenTypes.NUMBER, posStartNumber3, 2),
+          createToken(TokenTypes.KEYWORD, posStartThen, 'then'),
+          createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE'),
+          createToken(TokenTypes.KEYWORD, posStartEnd2, 'end'),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.STRING, posStartString, 'string'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const varX2Node: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x')
+        };
+        const varY2Node: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y')
+        };
+        const bodyNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.PLUS, posStartPlus),
+          leftChild: varX2Node,
+          rightChild: varY2Node
+        };
+
+        const functionDefNode: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONDEF,
+          token: createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          varNameToken: createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
+          argNameTokens: [createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+                          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y')],
+          bodyNode: bodyNode
+        };
+
+        const funcNameNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFuncCall, 'add')
+        };
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNumber1, 3)
+        };
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNumber2, 2)
+        };
+        const functionCallNode: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONCALL,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFuncCall, 'add'),
+          nodeToCall: funcNameNode,
+          argNodes: [numberNode1, numberNode2]
+        };
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNumber3, 2)
+        };
+        const compareNode: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.G_THAN, posStartGThan),
+          leftChild: functionCallNode,
+          rightChild: numberNode3
+        };
+
+        const trueNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.KEYWORD, posStartTrue, 'TRUE')
+        };
+        const ifNode: ASTNode = {
+          nodeType: NodeTypes.IFSTATEMENT,
+          token: createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
+          cases: [[compareNode, trueNode]],
+          elseCase: null
+        };
+
+        const stringNode: ASTNode = {
+          nodeType: NodeTypes.STRING,
+          token: createToken(TokenTypes.STRING, posStartString, 'string')
+        };
+
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          elementNodes: [functionDefNode, ifNode, stringNode]
+        };
+
+        let expected = new ParseResult();
+        expected.success(listNode);
+
+        for (let i = 0; i < 27; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+
+      it('should generate correct parse tree if multi-line code has multiple newlines', () => {
+        // code: x = 1\n\n\ny = 1
+        const posStartVarX = new PositionTracker(0, 1, 1);
+        const posStartEquals1 = new PositionTracker(2, 1, 3);
+        const posStartNum1 = new PositionTracker(4, 1, 5);
+        const posStartNewline1 = new PositionTracker(5, 1, 6);
+        const posStartNewline2 = new PositionTracker(6, 2, 1);
+        const posStartNewline3 = new PositionTracker(7, 3, 1);
+        const posStartVarY = new PositionTracker(8, 4, 1);
+        const posStartEquals2 = new PositionTracker(10, 4, 3);
+        const posStartNum2 = new PositionTracker(12, 4, 5);
+        const posStartEof = new PositionTracker(13, 4, 14);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.NEWLINE, posStartNewline3),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.NUMBER, posStartNum2, 1),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1)
+        };
+        const varXAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          node: numberNode1
+        };
+
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 1)
+        };
+        const varYAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          node: numberNode2
+        };
+
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          elementNodes: [varXAssignNode, varYAssignNode]
+        }
+
+        let expected = new ParseResult();
+        expected.success(listNode);
+
+        for (let i = 0; i < 9; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+
+      it('should generate correct error for erroneous line in multi-line code', () => {
+        // code: x = 1\ny = 2\nfinal = x z
+        const posStartVarX = new PositionTracker(0, 1, 1);
+        const posStartEquals1 = new PositionTracker(2, 1, 3);
+        const posStartNum1 = new PositionTracker(4, 1, 5);
+        const posStartNewline1 = new PositionTracker(5, 1, 6);
+        const posStartVarY = new PositionTracker(6, 2, 1);
+        const posStartEquals2 = new PositionTracker(8, 2, 3);
+        const posStartNum2 = new PositionTracker(10, 2, 5);
+        const posStartNewline2 = new PositionTracker(11, 2, 6);
+        const posStartVarFinal = new PositionTracker(12, 3, 1);
+        const posStartEquals3 = new PositionTracker(18, 3, 7);
+        const posStartVarX2 = new PositionTracker(20, 3, 9);
+        const posStartVarZ = new PositionTracker(22, 3, 11);
+        const posStartEof = new PositionTracker(23, 3, 12);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.NUMBER, posStartNum1, 1),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.NUMBER, posStartNum2, 2),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarFinal, 'final'),
+          createToken(TokenTypes.EQUALS, posStartEquals3),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.IDENTIFIER, posStartVarZ, 'z'),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 1),
+        };
+        const varXAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          node: numberNode1
+        };
+
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 2),
+        };
+        const varYAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
+          node: numberNode2
+        };
+
+        const varXAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x')
+        };
+        const varFinalAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarFinal, 'final'),
+          node: varXAccessNode
+        };
+
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
+          elementNodes: [varXAssignNode, varYAssignNode, varFinalAssignNode]
+        }
+
+        const error = new InvalidSyntaxError(`Expected '+', '-', '*', '/', '^', '==', '<', '>',` +
+                                             ` '<=', '>=', 'AND' or 'OR'`, posStartVarZ,
+                                             posStartEof);
+
+        let expected = new ParseResult();
+        expected.success(listNode);
+        expected.failure(error);
+
+        for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
     });
   });

--- a/src/app/logic/parser.spec.ts
+++ b/src/app/logic/parser.spec.ts
@@ -3105,15 +3105,14 @@ describe('Parser tests', () => {
     });
 
     describe('function definition and calls tests', () => {
-      it('should return correct AST for statement: function one() begin 1 end', () => {
+      it('should return correct AST for statement: function one() begin 1', () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
         const posStartRightBrack = new PositionTracker(13, 1, 14);
         const posStartBegin = new PositionTracker(15, 1, 16);
         const posStartNum = new PositionTracker(21, 1, 22);
-        const posStartEnd = new PositionTracker(23, 1, 24);
-        const posStartEof = new PositionTracker(26, 1, 27);
+        const posStartEof = new PositionTracker(22, 1, 23);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3122,7 +3121,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.R_BRACKET, posStartRightBrack),
           createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
           createToken(TokenTypes.NUMBER, posStartNum, 1),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3144,14 +3142,14 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 7; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 6; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it('should return correct AST for statement: function add(x, y) begin x + y end', () => {
+      it('should return correct AST for statement: function add(x, y) begin x + y', () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
@@ -3163,8 +3161,7 @@ describe('Parser tests', () => {
         const posStartVarX2 = new PositionTracker(25, 1, 26);
         const posStartPlus = new PositionTracker(27, 1, 28);
         const posStartVarY2 = new PositionTracker(29, 1, 30);
-        const posStartEnd = new PositionTracker(31, 1, 32);
-        const posStartEof = new PositionTracker(34, 1, 35);
+        const posStartEof = new PositionTracker(30, 1, 31);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3178,7 +3175,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3211,7 +3207,7 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 12; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -3219,7 +3215,7 @@ describe('Parser tests', () => {
       });
 
       // // Anonymous function support.
-      it('should return correct AST for statement: function (x, y) begin x + y end', () => {
+      it('should return correct AST for statement: function (x, y) begin x + y', () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartLeftBrack = new PositionTracker(9, 1, 10);
         const posStartVarX = new PositionTracker(10, 1, 11);
@@ -3230,8 +3226,7 @@ describe('Parser tests', () => {
         const posStartVarX2 = new PositionTracker(22, 1, 23);
         const posStartPlus = new PositionTracker(24, 1, 25);
         const posStartVarY2 = new PositionTracker(26, 1, 27);
-        const posStartEnd = new PositionTracker(28, 1, 29);
-        const posStartEof = new PositionTracker(31, 1, 32);
+        const posStartEof = new PositionTracker(27, 1, 28);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3244,7 +3239,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3277,14 +3271,14 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 10; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it('should return correct AST for statement: func = function (x, y) begin x + y end', () => {
+      it('should return correct AST for statement: func = function (x, y) begin x + y', () => {
         const posStartVariable = new PositionTracker(0, 1, 1);
         const posStartEquals = new PositionTracker(5, 1, 6);
         const posStartFunction = new PositionTracker(7, 1, 8);
@@ -3297,8 +3291,7 @@ describe('Parser tests', () => {
         const posStartVarX2 = new PositionTracker(29, 1, 30);
         const posStartPlus = new PositionTracker(31, 1, 32);
         const posStartVarY2 = new PositionTracker(33, 1, 34);
-        const posStartEnd = new PositionTracker(35, 1, 36);
-        const posStartEof = new PositionTracker(38, 1, 39);
+        const posStartEof = new PositionTracker(34, 1, 35);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.IDENTIFIER, posStartVariable, 'func'),
@@ -3313,7 +3306,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3352,7 +3344,7 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(ast);
 
-        for (let i = 0; i < 13; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 12; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -3575,7 +3567,7 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error expected '(' in parse result for expression: function add x, y) begin x + y end`, () => {
+      it(`should return correct error expected '(' in parse result for expression: function add x, y) begin x + y`, () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartVarX = new PositionTracker(11, 1, 12);
@@ -3586,8 +3578,7 @@ describe('Parser tests', () => {
         const posStartVarX2 = new PositionTracker(23, 1, 24);
         const posStartPlus = new PositionTracker(25, 1, 26);
         const posStartVarY2 = new PositionTracker(27, 1, 28);
-        const posStartEnd = new PositionTracker(29, 1, 30);
-        const posStartEof = new PositionTracker(32, 1, 33);
+        const posStartEof = new PositionTracker(28, 1, 29);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3600,7 +3591,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3620,7 +3610,7 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error missing ',' or ')' in parse result for expression: function add(x y) begin x + y end`, () => {
+      it(`should return correct error missing ',' or ')' in parse result for expression: function add(x y) begin x + y`, () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
@@ -3631,8 +3621,7 @@ describe('Parser tests', () => {
         const posStartVarX2 = new PositionTracker(20, 1, 21);
         const posStartPlus = new PositionTracker(22, 1, 23);
         const posStartVarY2 = new PositionTracker(24, 1, 25);
-        const posStartEnd = new PositionTracker(26, 1, 27);
-        const posStartEof = new PositionTracker(29, 1, 30);
+        const posStartEof = new PositionTracker(25, 1, 26);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3645,7 +3634,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3665,7 +3653,7 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error missing ',' or ')' in parse result for expression: function add(x, y begin x + y end`, () => {
+      it(`should return correct error missing ',' or ')' in parse result for expression: function add(x, y begin x + y`, () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
@@ -3677,8 +3665,7 @@ describe('Parser tests', () => {
         const posStartVarX2 = new PositionTracker(24, 1, 25);
         const posStartPlus = new PositionTracker(26, 1, 27);
         const posStartVarY2 = new PositionTracker(28, 1, 29);
-        const posStartEnd = new PositionTracker(30, 1, 31);
-        const posStartEof = new PositionTracker(33, 1, 34);
+        const posStartEof = new PositionTracker(29, 1, 30);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3691,7 +3678,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3711,7 +3697,7 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error 'Expected identifier' in parse result for expression: function add(x, ) begin x + y end`, () => {
+      it(`should return correct error 'Expected identifier' in parse result for expression: function add(x, ) begin x + y`, () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
@@ -3723,8 +3709,7 @@ describe('Parser tests', () => {
         const posStartVarX2 = new PositionTracker(24, 1, 25);
         const posStartPlus = new PositionTracker(26, 1, 27);
         const posStartVarY2 = new PositionTracker(28, 1, 29);
-        const posStartEnd = new PositionTracker(30, 1, 31);
-        const posStartEof = new PositionTracker(33, 1, 34);
+        const posStartEof = new PositionTracker(29, 1, 30);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3737,7 +3722,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3757,7 +3741,7 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct error missing 'begin' in parse result for expression: function add(x, y) x + y end`, () => {
+      it(`should return correct error missing 'begin' in parse result for expression: function add(x, y) x + y`, () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
@@ -3769,8 +3753,7 @@ describe('Parser tests', () => {
         const posEndVarX2 = new PositionTracker(20, 1, 21);
         const posStartPlus = new PositionTracker(21, 1, 22);
         const posStartVarY2 = new PositionTracker(23, 1, 24);
-        const posStartEnd = new PositionTracker(25, 1, 26);
-        const posStartEof = new PositionTracker(28, 1, 29);
+        const posStartEof = new PositionTracker(24, 1, 25);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3783,14 +3766,13 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
         const parser = new Parser(tokenList);
         const parseResult: ParseResult = parser.parse();
 
-        const error = new InvalidSyntaxError(`Expected 'begin' keyword`, posStartVarX2,
+        const error = new InvalidSyntaxError(`Expected 'begin' keyword or newline character`, posStartVarX2,
                                               posEndVarX2);
 
         let expected = new ParseResult();
@@ -3803,7 +3785,7 @@ describe('Parser tests', () => {
         expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
       });
 
-      it(`should return correct expression error in parse result for expression: function add(x, y) begin end`, () => {
+      it(`should return correct expression error in parse result for expression: function add(x, y) begin`, () => {
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
@@ -3812,9 +3794,8 @@ describe('Parser tests', () => {
         const posStartVarY = new PositionTracker(16, 1, 17);
         const posStartRightBrack = new PositionTracker(17, 1, 18);
         const posStartBegin = new PositionTracker(19, 1, 20);
-        const posStartEnd = new PositionTracker(25, 1, 26);
-        const posEndEnd = new PositionTracker(26, 1, 27);
-        const posStartEof = new PositionTracker(29, 1, 30);
+        const posStartEof = new PositionTracker(20, 1, 21);
+        const posEndEof = new PositionTracker(21, 1, 22);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -3825,7 +3806,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
           createToken(TokenTypes.R_BRACKET, posStartRightBrack),
           createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.EOF, posStartEof)
         ];
 
@@ -3833,57 +3813,12 @@ describe('Parser tests', () => {
         const parseResult: ParseResult = parser.parse();
 
         const error = new InvalidSyntaxError(`Expected a number, identifier, '+', '-', '(', '['` +
-                                             ` or 'NOT'`, posStartEnd, posEndEnd);
+                                             ` or 'NOT'`, posStartEof, posEndEof);
 
         let expected = new ParseResult();
         expected.failure(error);
 
         for (let i = 0; i < 8; i++) { expected.registerAdvancement(); }
-
-        expect(parseResult.getNode()).toEqual(expected.getNode());
-        expect(parseResult.getError()).toEqual(expected.getError());
-        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
-      });
-
-      it(`should return correct error missing 'end' in parse result for expression: function add(x, y) begin x + y`, () => {
-        const posStartFunction = new PositionTracker(0, 1, 1);
-        const posStartFuncName = new PositionTracker(9, 1, 10);
-        const posStartLeftBrack = new PositionTracker(12, 1, 13);
-        const posStartVarX = new PositionTracker(13, 1, 14);
-        const posStartComma = new PositionTracker(14, 1, 15);
-        const posStartVarY = new PositionTracker(16, 1, 17);
-        const posStartRightBrack = new PositionTracker(17, 1, 18);
-        const posStartBegin = new PositionTracker(19, 1, 20);
-        const posStartVarX2 = new PositionTracker(25, 1, 26);
-        const posStartPlus = new PositionTracker(27, 1, 28);
-        const posStartVarY2 = new PositionTracker(29, 1, 30);
-        const posStartEof = new PositionTracker(30, 1, 31);
-        const posEndEof = new PositionTracker(31, 1, 32);
-
-        const tokenList: Array<Token> = [
-          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
-          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'add'),
-          createToken(TokenTypes.L_BRACKET, posStartLeftBrack),
-          createToken(TokenTypes.IDENTIFIER, posStartVarX, 'x'),
-          createToken(TokenTypes.COMMA, posStartComma),
-          createToken(TokenTypes.IDENTIFIER, posStartVarY, 'y'),
-          createToken(TokenTypes.R_BRACKET, posStartRightBrack),
-          createToken(TokenTypes.KEYWORD, posStartBegin, 'begin'),
-          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
-          createToken(TokenTypes.PLUS, posStartPlus),
-          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.EOF, posStartEof)
-        ];
-
-        const parser = new Parser(tokenList);
-        const parseResult: ParseResult = parser.parse();
-
-        const error = new InvalidSyntaxError(`Expected 'end' keyword`, posStartEof, posEndEof);
-
-        let expected = new ParseResult();
-        expected.failure(error);
-
-        for (let i = 0; i < 11; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -3993,7 +3928,7 @@ describe('Parser tests', () => {
     // Block code is having multiple lines inside a function or if/elif/else/for/while loops.
     describe('multi-lined code with no block code tests', () => {
       it('should create list of outputs for each line for a given multi-line code', () => {
-        // code: function add(x, y) begin x + y end\nif add(3, 2) > 2 then TRUE\n"string"
+        // code: function add(x, y) begin x + y\nif add(3, 2) > 2 then TRUE\n"string"
         const posStartFunction = new PositionTracker(0, 1, 1);
         const posStartFuncName = new PositionTracker(9, 1, 10);
         const posStartLeftBrack = new PositionTracker(12, 1, 13);
@@ -4005,22 +3940,21 @@ describe('Parser tests', () => {
         const posStartVarX2 = new PositionTracker(25, 1, 26);
         const posStartPlus = new PositionTracker(27, 1, 28);
         const posStartVarY2 = new PositionTracker(29, 1, 30);
-        const posStartEnd = new PositionTracker(31, 1, 32);
-        const posStartNewline1 = new PositionTracker(34, 1, 35);
-        const posStartIf = new PositionTracker(35, 2, 1);
-        const posStartFuncCall = new PositionTracker(38, 2, 4);
-        const posStartLeftBrack2 = new PositionTracker(39, 2, 5);
-        const posStartNumber1 = new PositionTracker(40, 2, 6);
-        const posStartComma2 = new PositionTracker(41, 2, 7);
-        const posStartNumber2 = new PositionTracker(43, 2, 9);
-        const posStartRightBrack2 = new PositionTracker(44, 2, 10);
-        const posStartGThan = new PositionTracker(46, 2, 12);
-        const posStartNumber3 = new PositionTracker(48, 2, 14);
-        const posStartThen = new PositionTracker(50, 2, 16);
-        const posStartTrue = new PositionTracker(55, 2, 21);
-        const posStartNewline2 = new PositionTracker(63, 2, 29);
-        const posStartString = new PositionTracker(64, 3, 1);
-        const posStartEof = new PositionTracker(72, 3, 9);
+        const posStartNewline1 = new PositionTracker(30, 1, 31);
+        const posStartIf = new PositionTracker(31, 2, 1);
+        const posStartFuncCall = new PositionTracker(34, 2, 4);
+        const posStartLeftBrack2 = new PositionTracker(37, 2, 7);
+        const posStartNumber1 = new PositionTracker(38, 2, 8);
+        const posStartComma2 = new PositionTracker(39, 2, 9);
+        const posStartNumber2 = new PositionTracker(41, 2, 11);
+        const posStartRightBrack2 = new PositionTracker(42, 2, 12);
+        const posStartGThan = new PositionTracker(44, 2, 14);
+        const posStartNumber3 = new PositionTracker(46, 2, 16);
+        const posStartThen = new PositionTracker(48, 2, 18);
+        const posStartTrue = new PositionTracker(53, 2, 23);
+        const posStartNewline2 = new PositionTracker(57, 2, 27);
+        const posStartString = new PositionTracker(58, 3, 1);
+        const posStartEof = new PositionTracker(64, 3, 9);
 
         const tokenList: Array<Token> = [
           createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
@@ -4034,7 +3968,6 @@ describe('Parser tests', () => {
           createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
           createToken(TokenTypes.PLUS, posStartPlus),
           createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
-          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
           createToken(TokenTypes.NEWLINE, posStartNewline1),
           createToken(TokenTypes.KEYWORD, posStartIf, 'if'),
           createToken(TokenTypes.IDENTIFIER, posStartFuncCall, 'add'),
@@ -4133,7 +4066,7 @@ describe('Parser tests', () => {
         let expected = new ParseResult();
         expected.success(listNode);
 
-        for (let i = 0; i < 26; i++) { expected.registerAdvancement(); }
+        for (let i = 0; i < 25; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());
@@ -4946,6 +4879,216 @@ describe('Parser tests', () => {
         expected.success(listNode);
 
         for (let i = 0; i < 21; i++) { expected.registerAdvancement(); }
+
+        expect(parseResult.getNode()).toEqual(expected.getNode());
+        expect(parseResult.getError()).toEqual(expected.getError());
+        expect(parseResult.getAdvanceCount()).toEqual(expected.getAdvanceCount());
+      });
+
+      it('should produce correct AST for functions with block code', () => {
+        // Note: The tested source used would give a runtime error if executed by the interpreter
+        // since the output functions are not given string arguments.
+
+        // code: function doubleXTripleY(x, y)\nx = x * 2\ny = y * 3\noutput(x)\noutput(y)\nend\ndoubleXTripleY(10, 20)
+        const posStartFunction = new PositionTracker(0, 1, 1);
+        const posStartFuncName = new PositionTracker(9, 1, 10);
+        const posStartLeftBrack1 = new PositionTracker(23, 1, 24);
+        const posStartVarX1 = new PositionTracker(24, 1, 25);
+        const posStartComma1 = new PositionTracker(25, 1, 26);
+        const posStartVarY1 = new PositionTracker(27, 1, 28);
+        const posStartRightBrack1 = new PositionTracker(28, 1, 29);
+        const posStartNewline1 = new PositionTracker(29, 1, 30);
+        const posStartVarX2 = new PositionTracker(30, 2, 1);
+        const posStartEquals1 = new PositionTracker(32, 2, 3);
+        const posStartVarX3 = new PositionTracker(34, 2, 5);
+        const posStartMultiply1 = new PositionTracker(36, 2, 7);
+        const posStartNum1 = new PositionTracker(38, 2, 9);
+        const posStartNewline2 = new PositionTracker(39, 2, 10);
+        const posStartVarY2 = new PositionTracker(40, 3, 1);
+        const posStartEquals2 = new PositionTracker(42, 3, 3);
+        const posStartVarY3 = new PositionTracker(44, 3, 5);
+        const posStartMultiply2 = new PositionTracker(46, 3, 7);
+        const posStartNum2 = new PositionTracker(48, 3, 9);
+        const posStartNewline3 = new PositionTracker(49, 3, 10);
+        const posStartFuncCall1 = new PositionTracker(50, 4, 1);
+        const posStartLeftBrack2 = new PositionTracker(56, 4, 7);
+        const posStartVarX4 = new PositionTracker(57, 4, 8);
+        const posStartRightBrack2 = new PositionTracker(58, 4, 9);
+        const posStartNewline4 = new PositionTracker(59, 4, 10);
+        const posStartFuncCall2 = new PositionTracker(60, 5, 1);
+        const posStartLeftBrack3 = new PositionTracker(66, 5, 7);
+        const posStartVarY4 = new PositionTracker(67, 5, 8);
+        const posStartRightBrack3 = new PositionTracker(68, 5, 9);
+        const posStartNewline5 = new PositionTracker(69, 5, 10);
+        const posStartEnd = new PositionTracker(70, 6, 1);
+        const posStartNewline6 = new PositionTracker(73, 6, 4);
+        const posStartFuncCall3 = new PositionTracker(74, 7, 1);
+        const posStartLeftBrack4 = new PositionTracker(88, 7, 15);
+        const posStartNum3 = new PositionTracker(89, 7, 16);
+        const posStartComma2 = new PositionTracker(91, 7, 18);
+        const posStartNum4 = new PositionTracker(93, 7, 20);
+        const posStartRightBrack4 = new PositionTracker(95, 7, 22);
+        const posStartEof = new PositionTracker(96, 7, 23);
+
+        const tokenList: Array<Token> = [
+          createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'doubleXTripleY'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX1, 'x'),
+          createToken(TokenTypes.COMMA, posStartComma1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY1, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack1),
+          createToken(TokenTypes.NEWLINE, posStartNewline1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          createToken(TokenTypes.EQUALS, posStartEquals1),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX3, 'x'),
+          createToken(TokenTypes.MULTIPLY, posStartMultiply1),
+          createToken(TokenTypes.NUMBER, posStartNum1, 2),
+          createToken(TokenTypes.NEWLINE, posStartNewline2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          createToken(TokenTypes.EQUALS, posStartEquals2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY3, 'y'),
+          createToken(TokenTypes.MULTIPLY, posStartMultiply2),
+          createToken(TokenTypes.NUMBER, posStartNum2, 3),
+          createToken(TokenTypes.NEWLINE, posStartNewline3),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncCall1, 'output'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack2),
+          createToken(TokenTypes.IDENTIFIER, posStartVarX4, 'x'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack2),
+          createToken(TokenTypes.NEWLINE, posStartNewline4),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncCall2, 'output'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack3),
+          createToken(TokenTypes.IDENTIFIER, posStartVarY4, 'y'),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack3),
+          createToken(TokenTypes.NEWLINE, posStartNewline5),
+          createToken(TokenTypes.KEYWORD, posStartEnd, 'end'),
+          createToken(TokenTypes.NEWLINE, posStartNewline6),
+          createToken(TokenTypes.IDENTIFIER, posStartFuncCall3, 'doubleXTripleY'),
+          createToken(TokenTypes.L_BRACKET, posStartLeftBrack4),
+          createToken(TokenTypes.NUMBER, posStartNum3, 10),
+          createToken(TokenTypes.COMMA, posStartComma2),
+          createToken(TokenTypes.NUMBER, posStartNum4, 20),
+          createToken(TokenTypes.R_BRACKET, posStartRightBrack4),
+          createToken(TokenTypes.EOF, posStartEof)
+        ];
+
+        const parser = new Parser(tokenList);
+        const parseResult: ParseResult = parser.parse();
+
+        const numberNode1: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum1, 2)
+        };
+        const varXAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX3, 'x')
+        };
+        const multiplyNode1: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.MULTIPLY, posStartMultiply1),
+          leftChild: varXAccessNode,
+          rightChild: numberNode1
+        };
+        const varXAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          node: multiplyNode1
+        };
+
+        const numberNode2: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum2, 3)
+        };
+        const varYAccessNode: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY3, 'y')
+        };
+        const multiplyNode2: ASTNode = {
+          nodeType: NodeTypes.BINARYOP,
+          token: createToken(TokenTypes.MULTIPLY, posStartMultiply2),
+          leftChild: varYAccessNode,
+          rightChild: numberNode2
+        };
+        const varYAssignNode: ASTNode = {
+          nodeType: NodeTypes.VARASSIGN,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY2, 'y'),
+          node: multiplyNode2
+        };
+
+        const varXAccessNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX4, 'x')
+        };
+        const funcNameNode1: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFuncCall1, 'output')
+        };
+        const funcCallNode1: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONCALL,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFuncCall1, 'output'),
+          nodeToCall: funcNameNode1,
+          argNodes: [varXAccessNode2]
+        };
+
+        const varYAccessNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarY4, 'y')
+        };
+        const funcNameNode2: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFuncCall2, 'output')
+        };
+        const funcCallNode2: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONCALL,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFuncCall2, 'output'),
+          nodeToCall: funcNameNode2,
+          argNodes: [varYAccessNode2]
+        };
+
+        const bodyNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.IDENTIFIER, posStartVarX2, 'x'),
+          elementNodes: [varXAssignNode, varYAssignNode, funcCallNode1, funcCallNode2]
+        };
+        const functionDefNode: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONDEF,
+          token: createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          varNameToken: createToken(TokenTypes.IDENTIFIER, posStartFuncName, 'doubleXTripleY'),
+          argNameTokens: [
+            createToken(TokenTypes.IDENTIFIER, posStartVarX1, 'x'),
+            createToken(TokenTypes.IDENTIFIER, posStartVarY1, 'y'),
+          ],
+          bodyNode: bodyNode
+        };
+
+        const numberNode3: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum3, 10)
+        }
+        const numberNode4: ASTNode = {
+          nodeType: NodeTypes.NUMBER,
+          token: createToken(TokenTypes.NUMBER, posStartNum4, 20)
+        }
+        const funcNameNode3: ASTNode = {
+          nodeType: NodeTypes.VARACCESS,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFuncCall3, 'doubleXTripleY')
+        };
+        const funcCallNode3: ASTNode = {
+          nodeType: NodeTypes.FUNCTIONCALL,
+          token: createToken(TokenTypes.IDENTIFIER, posStartFuncCall3, 'doubleXTripleY'),
+          nodeToCall: funcNameNode3,
+          argNodes: [numberNode3, numberNode4]
+        }
+        const listNode: ASTNode = {
+          nodeType: NodeTypes.LIST,
+          token: createToken(TokenTypes.KEYWORD, posStartFunction, 'function'),
+          elementNodes: [functionDefNode, funcCallNode3]
+        };
+
+        let expected = new ParseResult();
+        expected.success(listNode);
+
+        for (let i = 0; i < 38; i++) { expected.registerAdvancement(); }
 
         expect(parseResult.getNode()).toEqual(expected.getNode());
         expect(parseResult.getError()).toEqual(expected.getError());

--- a/src/app/logic/parser.ts
+++ b/src/app/logic/parser.ts
@@ -187,8 +187,25 @@ export class Parser {
     parseResult.registerAdvancement();
     this.currentToken = this.advance();
 
-    if (!(this.currentToken.type === TokenTypes.KEYWORD && this.currentToken.value === 'begin')) {
-      const syntaxError = new InvalidSyntaxError(`Expected 'begin' keyword`,
+    if (this.currentToken.type === TokenTypes.KEYWORD && this.currentToken.value === 'begin') {
+      parseResult.registerAdvancement();
+      this.currentToken = this.advance();
+
+      const bodyNode: ASTNode = parseResult.register(this.expr());
+      if (parseResult.getError() !== null) { return parseResult; }
+
+      const functionDefNode: FunctionDefNode = {
+        nodeType: NodeTypes.FUNCTIONDEF,
+        token: functionToken,
+        varNameToken: varNameToken,
+        argNameTokens: argNameTokens,
+        bodyNode: bodyNode
+      };
+      return parseResult.success(functionDefNode);
+    }
+
+    if (this.currentToken.type !== TokenTypes.NEWLINE) {
+      const syntaxError = new InvalidSyntaxError(`Expected 'begin' keyword or newline character`,
                                                   this.currentToken.positionStart,
                                                   this.currentToken.positionEnd);
       return parseResult.failure(syntaxError);
@@ -197,7 +214,7 @@ export class Parser {
     parseResult.registerAdvancement();
     this.currentToken = this.advance();
 
-    const bodyNode: ASTNode = parseResult.register(this.expr());
+    const bodyNode: ASTNode = parseResult.register(this.statements());
     if (parseResult.getError() !== null) { return parseResult; }
 
     if (!(this.currentToken.type === TokenTypes.KEYWORD && this.currentToken.value === 'end')) {

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -1170,9 +1170,9 @@ describe('InterpreterService', () => {
       });
 
       // // NOTE: Has to be a false condition to prevent infinite loop during testing.
-      it('should produce an empty shell/console output for expression: while FALSE loop 1 end', () => {
+      it('should produce an empty shell/console output for expression: while FALSE loop 1', () => {
         service = new InterpreterService();
-        const source = 'while FALSE loop 1 end';
+        const source = 'while FALSE loop 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1219,27 +1219,14 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual(expectedErr);
       });
 
-      it(`should produce a missing 'loop' error shell/console output for expression: while FALSE 1 end`, () => {
+      it(`should produce a missing 'loop' error shell/console output for expression: while FALSE 1`, () => {
         service = new InterpreterService();
-        const source = 'while FALSE 1 end';
+        const source = 'while FALSE 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
         const expectedErr = `InvalidSyntaxError: Expected 'loop' keyword\nAt line: 1 column: 13 ` +
                             `and ends at line: 1 column: 14`;
-
-        expect(consoleOut).toEqual(expectedErr);
-        expect(shellOut).toEqual(expectedErr);
-      });
-
-      it(`should produce a missing 'end' error shell/console output for expression: while FALSE loop 1`, () => {
-        service = new InterpreterService();
-        const source = 'while FALSE loop 1';
-
-        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
-
-        const expectedErr = `InvalidSyntaxError: Expected 'end' keyword\nAt line: 1 column: 19 ` +
-                            `and ends at line: 1 column: 20`;
 
         expect(consoleOut).toEqual(expectedErr);
         expect(shellOut).toEqual(expectedErr);
@@ -1451,7 +1438,7 @@ describe('InterpreterService', () => {
 
       it('should show correct console output for valid multi-line code with output function used', () => {
         service = new InterpreterService();
-        const source = 'final = 5\nx = 1\nwhile x < final loop x = x + 1 end\noutput(toString(x))';
+        const source = 'final = 5\nx = 1\nwhile x < final loop x = x + 1\noutput(toString(x))';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1536,6 +1523,16 @@ describe('InterpreterService', () => {
 
         expect(consoleOut).toEqual('2\n3\n4\n5\n6');
         expect(shellOut).toEqual('2\n3\n4\n5\n6');
+      });
+
+      it('should output correct variable value inside the block statement in the while statement', () => {
+        service = new InterpreterService();
+        const source = 'x = 0\nfinal = 2\nwhile x < final loop\nx = x + 1\nend\noutput(toString(x))';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('2');
+        expect(shellOut).toEqual('2');
       });
     });
   });

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -290,9 +290,9 @@ describe('InterpreterService', () => {
           expect(shellOut).toEqual('[1, 2, string]');
         });
 
-        it(`should return empty console output with shell output '[1, <function x>]' for expression: [1, function x() begin 1 end]`, () => {
+        it(`should return empty console output with shell output '[1, <function x>]' for expression: [1, function x() begin 1]`, () => {
           service = new InterpreterService();
-          const source = '[1, function x() begin 1 end]';
+          const source = '[1, function x() begin 1]';
 
           const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1236,7 +1236,7 @@ describe('InterpreterService', () => {
     describe('function definition and calls tests', () => {
       it('should return function value by its name, when defined, in the shell output', () => {
         service = new InterpreterService();
-        const source = 'function add(x, y) begin x + y end';
+        const source = 'function add(x, y) begin x + y';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1246,7 +1246,7 @@ describe('InterpreterService', () => {
 
       it('should return function value by its name <anonymous>, when defined, in the shell output', () => {
         service = new InterpreterService();
-        const source = 'function (x, y) begin x + y end';
+        const source = 'function (x, y) begin x + y';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1322,7 +1322,7 @@ describe('InterpreterService', () => {
 
         it('should return runtime error when passing an argument that is a FunctionType', () => {
           service = new InterpreterService();
-          const source = 'toString(function func() begin 1 end)';
+          const source = 'toString(function func() begin 1)';
 
           const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1396,7 +1396,7 @@ describe('InterpreterService', () => {
 
         it('should return runtime error when passing an argument that is a FunctionType', () => {
           service = new InterpreterService();
-          const source = 'output(function func() begin 1 end)';
+          const source = 'output(function func() begin 1)';
 
           const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1428,7 +1428,7 @@ describe('InterpreterService', () => {
     describe('multi-line code with no block code tests', () => {
       it('should output to shell a list of outputs for each line statement', () => {
         service = new InterpreterService();
-        const source = 'function add(x, y) begin x + y end\nif add(3, 2) > 2 then TRUE\n"string"';
+        const source = 'function add(x, y) begin x + y\nif add(3, 2) > 2 then TRUE\n"string"';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1533,6 +1533,17 @@ describe('InterpreterService', () => {
 
         expect(consoleOut).toEqual('2');
         expect(shellOut).toEqual('2');
+      });
+
+      it('should output correct variable values inside the block statement in the function', () => {
+        service = new InterpreterService();
+        const source = 'function doubleXTripleY(x, y)\nx = x * 2\ny = y * 3\noutput(toString(x))' +
+                       '\noutput(toString(y))\nend\ndoubleXTripleY(10, 20)';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('20\n60');
+        expect(shellOut).toEqual('20\n60');
       });
     });
   });

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -1071,9 +1071,9 @@ describe('InterpreterService', () => {
     });
 
     describe('if, elif and else statement tests', () => {
-      it(`should produce a shell output of '2' for expression: if PI > 3 then 1 + 1 end`, () => {
+      it(`should produce a shell output of '2' for expression: if PI > 3 then 1 + 1`, () => {
         service = new InterpreterService();
-        const source = 'if PI > 3 then 1 + 1 end';
+        const source = 'if PI > 3 then 1 + 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1081,9 +1081,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual('2');
       });
 
-      it(`should produce a shell output of '100' for expression: if PI == 3 then 1 + 1 else 100 end`, () => {
+      it(`should produce a shell output of '100' for expression: if PI == 3 then 1 + 1 else 100`, () => {
         service = new InterpreterService();
-        const source = 'if PI == 3 then 1 + 1 else 100 end';
+        const source = 'if PI == 3 then 1 + 1 else 100';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1091,9 +1091,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual('100');
       });
 
-      it(`should produce a shell output of '1' for expression: if FALSE then 5 elif TRUE then 1 else 100 end`, () => {
+      it(`should produce a shell output of '1' for expression: if FALSE then 5 elif TRUE then 1 else 100`, () => {
         service = new InterpreterService();
-        const source = 'if FALSE then 5 elif TRUE then 1 else 100 end';
+        const source = 'if FALSE then 5 elif TRUE then 1 else 100';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1101,9 +1101,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual('1');
       });
 
-      it(`should produce a shell output of '0' for expression: if FALSE then 5 elif FALSE then 1 elif TRUE then 0 else 100 end`, () => {
+      it(`should produce a shell output of '0' for expression: if FALSE then 5 elif FALSE then 1 elif TRUE then 0 else 100`, () => {
         service = new InterpreterService();
-        const source = 'if FALSE then 5 elif FALSE then 1 elif TRUE then 0 else 100 end';
+        const source = 'if FALSE then 5 elif FALSE then 1 elif TRUE then 0 else 100';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1111,9 +1111,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual('0');
       });
 
-      it(`should produce a console/shell syntax error missing 'then' keyword for expression: if TRUE 5 end`, () => {
+      it(`should produce a console/shell syntax error missing 'then' keyword for expression: if TRUE 5`, () => {
         service = new InterpreterService();
-        const source = 'if TRUE 5 end';
+        const source = 'if TRUE 5';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1124,22 +1124,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual(expectedErr);
       });
 
-      it(`should produce a console/shell syntax error missing 'end' keyword for expression: if TRUE then 5`, () => {
+      it(`should produce a console/shell syntax error missing 'then' keyword for expression: if FALSE then 5 elif TRUE 1`, () => {
         service = new InterpreterService();
-        const source = 'if TRUE then 5';
-
-        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
-
-        const expectedErr = `InvalidSyntaxError: Expected 'end' keyword\nAt line: 1 column:` +
-                            ` 15 and ends at line: 1 column: 16`;
-
-        expect(consoleOut).toEqual(expectedErr);
-        expect(shellOut).toEqual(expectedErr);
-      });
-
-      it(`should produce a console/shell syntax error missing 'then' keyword for expression: if FALSE then 5 elif TRUE 1 end`, () => {
-        service = new InterpreterService();
-        const source = 'if FALSE then 5 elif TRUE 1 end';
+        const source = 'if FALSE then 5 elif TRUE 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1467,7 +1454,7 @@ describe('InterpreterService', () => {
     describe('multi-line code with no block code tests', () => {
       it('should output to shell a list of outputs for each line statement', () => {
         service = new InterpreterService();
-        const source = 'function add(x, y) begin x + y end\nif add(3, 2) > 2 then TRUE end\n"string"';
+        const source = 'function add(x, y) begin x + y end\nif add(3, 2) > 2 then TRUE\n"string"';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1504,6 +1491,51 @@ describe('InterpreterService', () => {
         const expectedError = `Traceback (most recent call last):\nLine 3, in <pseudo>\nRuntime` +
                               ` Error: z is not defined\nAt line: 3 column: 14 and ends at ` +
                               `line: 3 column: 15`;
+
+        expect(consoleOut).toEqual(expectedError);
+        expect(shellOut).toEqual(expectedError);
+      });
+    });
+
+    describe('multi-line code with block code tests', () => {
+      it('should output correct variable value inside the block statement in the if statement', () => {
+        service = new InterpreterService();
+        const source = 'if 1 > 0 then\nx = 0\ny = 1\nend\noutput(toString(y))';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('1');
+        expect(shellOut).toEqual('1');
+      });
+
+      it('should output correct variable value inside the block statement in the else statement', () => {
+        service = new InterpreterService();
+        const source = 'if 1 < 0 then\nx = 0\ny = 1\nelse\nx = 100\nend';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('');
+        expect(shellOut).toEqual('[100]');
+      });
+
+      it('should output correct variable value inside the block statement in the elif statement', () => {
+        service = new InterpreterService();
+        const source = 'if 1 < 0 then\nx = 0\ny = 1\nelif 2 < 3 then\noutput("success")\nelse\nx = 100\nend';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('success');
+        expect(shellOut).toEqual('success');
+      });
+
+      it(`should output syntax error for block if, elif and else statement missing 'end' keyword`, () => {
+        service = new InterpreterService();
+        const source = 'if 1 < 0 then\nx = 0\ny = 1\nelif 2 < 3 then\noutput("success")\nelse\nx = 100';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        const expectedError = `InvalidSyntaxError: Expected 'end' keyword\nAt line: 7 column:` +
+                              ` 8 and ends at line: 7 column: 9`;
 
         expect(consoleOut).toEqual(expectedError);
         expect(shellOut).toEqual(expectedError);

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -1139,9 +1139,9 @@ describe('InterpreterService', () => {
     });
 
     describe('for and while loop tests', () => {
-      it('should produce an empty shell/console output for expression: for i = 1 to 10 loop 1 end', () => {
+      it('should produce an empty shell/console output for expression: for i = 1 to 10 loop 1', () => {
         service = new InterpreterService();
-        const source = 'for i = 1 to 10 loop 1 end';
+        const source = 'for i = 1 to 10 loop 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1149,9 +1149,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual('');
       });
 
-      it('should produce an empty shell/console output for expression: for i = 1 to 10 step 2 loop 1 end', () => {
+      it('should produce an empty shell/console output for expression: for i = 1 to 10 step 2 loop 1', () => {
         service = new InterpreterService();
-        const source = 'for i = 1 to 10 step 2 loop 1 end';
+        const source = 'for i = 1 to 10 step 2 loop 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1159,9 +1159,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual('');
       });
 
-      it('should produce an empty shell/console output for expression: for i = 10 to 0 step -1 loop 1 end', () => {
+      it('should produce an empty shell/console output for expression: for i = 10 to 0 step -1 loop 1', () => {
         service = new InterpreterService();
-        const source = 'for i = 10 to 0 step -1 loop 1 end';
+        const source = 'for i = 10 to 0 step -1 loop 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1180,9 +1180,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual('');
       });
 
-      it(`should produce a missing '=' error shell/console output for expression: for i 1 to 10 loop 1 end`, () => {
+      it(`should produce a missing '=' error shell/console output for expression: for i 1 to 10 loop 1`, () => {
         service = new InterpreterService();
-        const source = 'for i 1 to 10 loop 1 end';
+        const source = 'for i 1 to 10 loop 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1193,9 +1193,9 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual(expectedErr);
       });
 
-      it(`should produce a missing 'to' error shell/console output for expression: for i = 1 10 loop 1 end`, () => {
+      it(`should produce a missing 'to' error shell/console output for expression: for i = 1 10 loop 1`, () => {
         service = new InterpreterService();
-        const source = 'for i = 1 10 loop 1 end';
+        const source = 'for i = 1 10 loop 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1206,27 +1206,14 @@ describe('InterpreterService', () => {
         expect(shellOut).toEqual(expectedErr);
       });
 
-      it(`should produce a missing 'loop' error shell/console output for expression: for i = 1 to 10 1 end`, () => {
+      it(`should produce a missing 'loop' error shell/console output for expression: for i = 1 to 10 1`, () => {
         service = new InterpreterService();
-        const source = 'for i = 1 to 10 1 end';
+        const source = 'for i = 1 to 10 1';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
         const expectedErr = `InvalidSyntaxError: Expected 'loop' keyword\nAt line: 1 column: 17 ` +
                             `and ends at line: 1 column: 18`;
-
-        expect(consoleOut).toEqual(expectedErr);
-        expect(shellOut).toEqual(expectedErr);
-      });
-
-      it(`should produce a missing 'end' error shell/console output for expression: for i = 1 to 10 loop 1`, () => {
-        service = new InterpreterService();
-        const source = 'for i = 1 to 10 loop 1';
-
-        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
-
-        const expectedErr = `InvalidSyntaxError: Expected 'end' keyword\nAt line: 1 column: 23 ` +
-                            `and ends at line: 1 column: 24`;
 
         expect(consoleOut).toEqual(expectedErr);
         expect(shellOut).toEqual(expectedErr);
@@ -1539,6 +1526,16 @@ describe('InterpreterService', () => {
 
         expect(consoleOut).toEqual(expectedError);
         expect(shellOut).toEqual(expectedError);
+      });
+
+      it('should output correct variable value inside the block statement in the for statement', () => {
+        service = new InterpreterService();
+        const source = 'for i = 1 to 5 loop\nx = i + 1\noutput(toString(x))\nend';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('2\n3\n4\n5\n6');
+        expect(shellOut).toEqual('2\n3\n4\n5\n6');
       });
     });
   });

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -29,6 +29,7 @@ export class InterpreterService {
 
   constructor() {
     this.lexer = new Lexer();
+    this.outputs = [];
   }
 
   public evaluate(source: string): [string, string] {
@@ -284,7 +285,7 @@ export class InterpreterService {
       if (runtimeResult.getError() !== null) { return runtimeResult; }
     }
 
-    let returnValue: ValueType = runtimeResult.register(functionVal.execute(args));
+    let returnValue: ValueType = runtimeResult.register(functionVal.execute(args, this));
     if (runtimeResult.getError() !== null) { return runtimeResult; }
 
     if (returnValue instanceof NumberType || returnValue instanceof StringType ||

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -38,6 +38,8 @@ export class InterpreterService {
     let runtimeResult: RuntimeResult;
     this.outputs = [];
 
+    if (this.isEmptySourceCode(source)) { return ['', '']; }
+
     let lexerOutput: Array<Token> | Error = this.lexer.lex(source);
 
     if (lexerOutput instanceof Error) {
@@ -65,7 +67,9 @@ export class InterpreterService {
           consoleOutput = consoleOutput.substring(0, consoleOutput.length - 1)
 
           if (this.outputs.length > 0) { shellOutput = consoleOutput; }
-          else { shellOutput = this.generateShellOutput(runtimeResult); }
+          else {
+            shellOutput = this.generateShellOutput(runtimeResult);
+          }
         }
       }
     }
@@ -112,6 +116,15 @@ export class InterpreterService {
     globalSymbolTable.set('PI', new NumberType(Math.PI));
 
     return globalSymbolTable;
+  }
+
+  // Checks if all the source code has is newlines and whitespaces.
+  private isEmptySourceCode(source: string): boolean {
+    for (let char of source) {
+      if (char !== '\n' && char !== ' ') { return false; }
+    }
+
+    return true;
   }
 
   private generateShellOutput(runtimeResult: RuntimeResult): string {

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -371,10 +371,10 @@ export class InterpreterService {
     let i: number = startValNum;
     let rangeCondition: ((currVal: number, endVal: number) => boolean);
     if (stepValNum >= 0) {
-      rangeCondition = (currVal: number, endVal: number) => { return i < endValNum; }
+      rangeCondition = (currVal: number, endVal: number) => { return i <= endValNum; }
     }
     else {
-      rangeCondition = (currVal: number, endVal: number) => { return i > endValNum; }
+      rangeCondition = (currVal: number, endVal: number) => { return i >= endValNum; }
     }
 
     while (rangeCondition(i, endValNum)) {


### PR DESCRIPTION
The language now supports multi-line statements of code which uses the newline character as a delimiter, e.g:

`x = 1\ny = 2\noutput(toString(y))`

The language also now handles empty code and code that has just newline characters by outputting an empty value to the shell/console. The language also supports block statements inside some of the supported language structures such as: if/elif/else statements, for/while loops and functions. Examples for each are shown below:

- `if 10 > 0 then\nstring = "success"\noutput(string)\nelse\noutput("fail")\nend`
- `for i = 1 to 10 loop\nx = i * 2\noutput(toString(x))\nend`
- `x = 1\nfinal = 3\nwhile x < final loop\nx = x + 1\nend`
- `function doubleXTripleY(x, y)\nx = x * 2\ny = y * 3\noutput(toString(x))\noutput(toString(y))\nend\ndoubleXTripleY(1, 2)`

There has also been a change made to the single-lined version of these statements, where the `end` keyword is no longer required at the end of the single-lined statement.