### PR TITLE
feat(return-statements): added return statements for functions

### DIFF
--- a/src/app/constants/keywords.constants.ts
+++ b/src/app/constants/keywords.constants.ts
@@ -1,4 +1,4 @@
 export const KEYWORDS = new Set([
   'AND', 'OR', 'NOT', 'TRUE', 'FALSE', 'if', 'then', 'elif', 'else', 'end', 'for', 'to', 'step',
-  'loop', 'while', 'function', 'begin'
+  'loop', 'while', 'function', 'begin', 'return'
 ]);

--- a/src/app/constants/node-type.constants.ts
+++ b/src/app/constants/node-type.constants.ts
@@ -10,3 +10,4 @@ export const FORLOOP = 'ForNode';
 export const WHILELOOP = 'WhileNode';
 export const FUNCTIONDEF = 'FunctionDefNode';
 export const FUNCTIONCALL = 'FunctionCallNode';
+export const RETURN = 'ReturnNode';

--- a/src/app/data-types/function-type.spec.ts
+++ b/src/app/data-types/function-type.spec.ts
@@ -9,6 +9,7 @@ import * as TokenTypes from '../constants/token-type.constants';
 import {createToken} from '../utils/token-functions';
 import { SymbolTable } from '../logic/symbol-table';
 import { InterpreterService } from '../services/interpreter.service';
+import { ValueType } from './value-type';
 
 describe('FunctionType tests', () => {
   describe('execute tests', () => {
@@ -49,8 +50,8 @@ describe('FunctionType tests', () => {
       functionType.getContext().symbolTable.set('y', number2);
 
       const interpreter = new InterpreterService();
-      const value: NumberType = <NumberType>functionType.execute([number1, number2], interpreter).getValue();
-      expect(value.getValue()).toEqual(3);
+      const value: ValueType = functionType.execute([number1, number2], interpreter).getFuncReturnValue();
+      expect(value).toEqual(null);
     });
 
     it('should return runtime result error for to few arguments', () => {

--- a/src/app/data-types/function-type.ts
+++ b/src/app/data-types/function-type.ts
@@ -21,7 +21,7 @@ export class FunctionType extends ValueType {
     newContext.symbolTable = new SymbolTable(newContext.getParent().symbolTable);
 
     runtimeResult = this.checkArgLengths(args);
-    if (runtimeResult.getError() !== null) { return runtimeResult; }
+    if (runtimeResult.shouldReturn()) { return runtimeResult; }
 
     for (let i = 0; i < args.length; i++) {
       const argName: string = this.argNames[i];
@@ -31,10 +31,15 @@ export class FunctionType extends ValueType {
       newContext.symbolTable.set(argName, argValue);
     }
 
-    const value: ValueType = runtimeResult.register(interpreter.visitNode(this.bodyNode, newContext));
-    if (runtimeResult.getError() !== null) { return runtimeResult; }
+    runtimeResult.register(interpreter.visitNode(this.bodyNode, newContext));
+    if (runtimeResult.shouldReturn() && runtimeResult.getFuncReturnValue() === null) {
+      return runtimeResult;
+    }
 
-    return runtimeResult.success(value);
+    const returnValue = runtimeResult.getFuncReturnValue() !== null ?
+                        runtimeResult.getFuncReturnValue() : null;
+
+    return runtimeResult.success(returnValue);
   }
 
   public copy(): FunctionType {

--- a/src/app/logic/lexer.spec.ts
+++ b/src/app/logic/lexer.spec.ts
@@ -796,7 +796,7 @@ describe('Lexer tests', () => {
             [TokenTypes.IDENTIFIER, posTracker4, 'x'], [TokenTypes.COMMA, posTracker5],
             [TokenTypes.IDENTIFIER, posTracker6, 'y'], [TokenTypes.R_BRACKET, posTracker7],
             [TokenTypes.KEYWORD, posTracker8, 'begin'], [TokenTypes.NEWLINE, posTracker9],
-            [TokenTypes.IDENTIFIER, posTracker10, 'return'],
+            [TokenTypes.KEYWORD, posTracker10, 'return'],
             [TokenTypes.IDENTIFIER, posTracker11, 'x'], [TokenTypes.PLUS, posTracker12],
             [TokenTypes.IDENTIFIER, posTracker13, 'y'], [TokenTypes.NEWLINE, posTracker14],
             [TokenTypes.KEYWORD, posTracker15, 'end'], [TokenTypes.NEWLINE, posTracker16]

--- a/src/app/logic/parser.ts
+++ b/src/app/logic/parser.ts
@@ -191,7 +191,7 @@ export class Parser {
       parseResult.registerAdvancement();
       this.currentToken = this.advance();
 
-      const bodyNode: ASTNode = parseResult.register(this.expr());
+      const bodyNode: ASTNode = parseResult.register(this.statement());
       if (parseResult.getError() !== null) { return parseResult; }
 
       const functionDefNode: FunctionDefNode = {

--- a/src/app/logic/runtime-result.ts
+++ b/src/app/logic/runtime-result.ts
@@ -2,25 +2,49 @@ import { RuntimeError } from './runtime-error';
 import { ValueType } from '../data-types/value-type';
 
 export class RuntimeResult {
-  private value: ValueType = null;
-  private error: RuntimeError = null;
+  private value: ValueType;
+  private error: RuntimeError;
+  private funcReturnValue: ValueType;
+
+  constructor() { this.reset(); }
+
+  private reset(): void {
+    this.value = null;
+    this.error = null;
+    this.funcReturnValue = null;
+  }
 
   public register(result: RuntimeResult): ValueType {
-    if (result.getError() !== null) { this.error = result.getError(); }
+    this.error = result.getError();
+    this.funcReturnValue = result.getFuncReturnValue();
     return result.value;
   }
 
   public success(value: ValueType): RuntimeResult {
+    this.reset();
     this.value = value;
     return this;
   }
 
+  public returnSuccess(value: ValueType): RuntimeResult {
+    this.reset();
+    this.funcReturnValue = value;
+    return this;
+  }
+
   public failure(error: RuntimeError): RuntimeResult {
+    this.reset();
     this.error = error;
     return this;
   }
 
+  public shouldReturn(): boolean {
+    return this.error !== null || this.funcReturnValue !== null;
+  }
+
   public getValue(): ValueType { return this.value; }
+
+  public getFuncReturnValue(): ValueType { return this.funcReturnValue; }
 
   public getError(): RuntimeError { return this.error; }
 }

--- a/src/app/models/ast-node.ts
+++ b/src/app/models/ast-node.ts
@@ -18,5 +18,6 @@ export interface ASTNode {
   argNameTokens?: Token[],
   nodeToCall?: ASTNode,
   argNodes?: ASTNode[],
-  elementNodes?: ASTNode[]
+  elementNodes?: ASTNode[],
+  nodeToReturn?: ASTNode
 }

--- a/src/app/models/return-node.ts
+++ b/src/app/models/return-node.ts
@@ -1,0 +1,8 @@
+import { ASTNode } from './ast-node';
+import { Token } from './token';
+
+export interface ReturnNode extends ASTNode {
+  nodeType: string,
+  token: Token,
+  nodeToReturn: ASTNode
+}

--- a/src/app/services/interpreter.service.spec.ts
+++ b/src/app/services/interpreter.service.spec.ts
@@ -1428,7 +1428,7 @@ describe('InterpreterService', () => {
     describe('multi-line code with no block code tests', () => {
       it('should output to shell a list of outputs for each line statement', () => {
         service = new InterpreterService();
-        const source = 'function add(x, y) begin x + y\nif add(3, 2) > 2 then TRUE\n"string"';
+        const source = 'function add(x, y) begin return x + y\nif add(3, 2) > 2 then TRUE\n"string"';
 
         const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
 
@@ -1544,6 +1544,16 @@ describe('InterpreterService', () => {
 
         expect(consoleOut).toEqual('20\n60');
         expect(shellOut).toEqual('20\n60');
+      });
+
+      it('should output correct variable values inside the block statement in the function', () => {
+        service = new InterpreterService();
+        const source = 'function sum(x, y)\ntotal = x + y\nreturn total\nend\nsum(10, 50)';
+
+        const [consoleOut, shellOut]: [string, string] = service.evaluate(source);
+
+        expect(consoleOut).toEqual('');
+        expect(shellOut).toEqual('[<function sum>, 60]');
       });
     });
   });


### PR DESCRIPTION
Functions now support return statements to return actual values from the functions scope to its parent scope. Functions will otherwise not return a `ValueType`. The syntax for return statements are as follows:

- return [expression]

where they return a null value if used outside a function. Return statements also end the execution of a function when executed.