### PR TITLE
feat(incorporate-interpreter): added interpreter to play button mechanism

### DIFF
--- a/src/app/components/code-editor/code-editor.component.html
+++ b/src/app/components/code-editor/code-editor.component.html
@@ -3,7 +3,7 @@
 <div #lineNumberContainer [scrollTop]="getScrollTop()" class="line-number-container">
   <div *ngFor="let number of getLineNumberArray()" class="line-number">{{number}}</div>
 </div>
-<div #inputRegion (input)="updateLineNumber()" 
+<div #inputRegion (input)="onTextInput()" 
 (scroll)="syncEditorAndLineNumScrolling()" class="input-region" contenteditable="true">
 
 </div>

--- a/src/app/components/code-editor/code-editor.component.spec.ts
+++ b/src/app/components/code-editor/code-editor.component.spec.ts
@@ -187,7 +187,7 @@ describe('CodeEditorComponent', () => {
         const inputRegion = codeEditorElement.querySelector('div.input-region');
 
         inputRegion.innerHTML = '<div><br></div><div><br></div>';
-        component.updateLineNumber();
+        component.onTextInput();
 
         const expected: number[] = [1, 2];
 
@@ -205,7 +205,7 @@ describe('CodeEditorComponent', () => {
                                  <div>Line 4</div>
                                  <div>Line 5</div>`;
 
-        component.updateLineNumber();
+        component.onTextInput();
 
         const expected: number[] = [1, 2, 3, 4, 5];
 
@@ -219,7 +219,7 @@ describe('CodeEditorComponent', () => {
 
         inputRegion.innerHTML = `Line 1<div>Line 2</div><div>Line 3</div>`;
 
-        component.updateLineNumber();
+        component.onTextInput();
 
         const expected: number[] = [1, 2, 3];
 
@@ -233,7 +233,7 @@ describe('CodeEditorComponent', () => {
 
         inputRegion.innerHTML = `<div>Line 1</div><div>Line 2</div><div><br></div>`;
 
-        component.updateLineNumber();
+        component.onTextInput();
 
         const expected: number[] = [1, 2, 3];
 

--- a/src/app/components/code-editor/code-editor.component.ts
+++ b/src/app/components/code-editor/code-editor.component.ts
@@ -20,7 +20,11 @@ export class CodeEditorComponent implements OnInit {
     this.windowSizeService.editorCast.subscribe(editorWidth => this.width = editorWidth);
   }
 
-  public updateLineNumber(): void {
+  public onTextInput(): void {
+    this.updateLineNumber();
+  }
+
+  private updateLineNumber(): void {
 
     const text: string = this.inputRegion.nativeElement.innerText;
     const linesArr: string[] = text.split('\n');

--- a/src/app/components/code-editor/code-editor.component.ts
+++ b/src/app/components/code-editor/code-editor.component.ts
@@ -1,3 +1,4 @@
+import { ConsoleTextService } from './../../services/console-text.service';
 import { WindowSizeService } from './../../services/window-size.service';
 import { Component, ElementRef, ViewChild, OnInit, HostBinding } from '@angular/core';
 
@@ -14,7 +15,8 @@ export class CodeEditorComponent implements OnInit {
   @ViewChild('inputRegion') inputRegion: ElementRef<HTMLElement>;
   @HostBinding('style.width.%') private width: number;
 
-  constructor(private windowSizeService: WindowSizeService) {}
+  constructor(private windowSizeService: WindowSizeService,
+              private consoleTextService: ConsoleTextService) {}
 
   ngOnInit() {
     this.windowSizeService.editorCast.subscribe(editorWidth => this.width = editorWidth);
@@ -22,6 +24,9 @@ export class CodeEditorComponent implements OnInit {
 
   public onTextInput(): void {
     this.updateLineNumber();
+
+    const text: string = this.inputRegion.nativeElement.innerText;
+    this.consoleTextService.setInput(text);
   }
 
   private updateLineNumber(): void {

--- a/src/app/components/output-console/output-console.component.spec.ts
+++ b/src/app/components/output-console/output-console.component.spec.ts
@@ -153,56 +153,6 @@ describe('OutputConsoleComponent', () => {
 
         expect(outputRegion.innerHTML).toBe('');
       });
-
-      it('should have a line of text in innerHTML when calling outputText with that line.', () => {
-
-        const outputConsoleElement: HTMLElement = fixture.nativeElement;
-        const outputRegion = outputConsoleElement.querySelector('div.output-region');
-
-        component.outputText('Output 1.');
-
-        fixture.detectChanges();
-
-        const expected: string = 'Output 1.';
-
-        expect(outputRegion.innerHTML).toBe(expected);
-      });
-
-      it('should have 5 lines of text in innerHTML when calling outputText with 5 lines of text.', () => {
-
-        const outputConsoleElement: HTMLElement = fixture.nativeElement;
-        const outputRegion = outputConsoleElement.querySelector('div.output-region');
-
-        const htmlArr: string[] = [];
-
-        for (let i = 1; i < 6; i++) {
-          htmlArr.push(`Line ${i}`);
-        }
-
-        const htmlText: string = htmlArr.join('<br>');
-
-        component.outputText(htmlText);
-
-        fixture.detectChanges();
-
-        const expected: string = `Line 1<br>Line 2<br>Line 3<br>Line 4<br>Line 5`;
-
-        expect(outputRegion.innerHTML).toBe(expected);
-      });
-
-      it('should have an empty line of text in innerHTML when calling outputText with that empty line.', () => {
-
-        const outputConsoleElement: HTMLElement = fixture.nativeElement;
-        const outputRegion = outputConsoleElement.querySelector('div.output-region');
-
-        component.outputText('');
-
-        fixture.detectChanges();
-
-        const expected: string = '';
-
-        expect(outputRegion.innerHTML).toBe(expected);
-      });
     });
   });
 });

--- a/src/app/components/output-console/output-console.component.ts
+++ b/src/app/components/output-console/output-console.component.ts
@@ -1,3 +1,4 @@
+import { ConsoleTextService } from './../../services/console-text.service';
 import { WindowSizeService } from './../../services/window-size.service';
 import { Component, OnInit, HostBinding } from '@angular/core';
 
@@ -9,19 +10,20 @@ import { Component, OnInit, HostBinding } from '@angular/core';
 export class OutputConsoleComponent implements OnInit {
 
   @HostBinding('style.width.%') private width: number;
-  private output: string = '';
+  // private output: string = '';
 
-  constructor(private windowSizeService: WindowSizeService) {}
+  constructor(private windowSizeService: WindowSizeService,
+              private consoleTextService: ConsoleTextService) {}
 
   ngOnInit() {
     this.windowSizeService.outputCast.subscribe(outputWidth => this.width = outputWidth);
   }
 
-  public outputText(htmlText: string): void {
-    this.output = htmlText;
-  }
+  // public outputText(htmlText: string): void {
+  //   this.output = htmlText;
+  // }
 
   public getOutput(): string {
-    return this.output;
+    return this.consoleTextService.getOutput();
   }
 }

--- a/src/app/components/run-button/run-button.component.ts
+++ b/src/app/components/run-button/run-button.component.ts
@@ -15,10 +15,7 @@ export class RunButtonComponent {
   @HostListener('click')
   onClick() {
     let source = this.consoleTextService.getInput();
-    source = source.replace(/^(&nbsp;|<br>)+/, '');
-    console.log(source);
     let [consOut, shellOut] = this.interpreter.evaluate(source);
-    console.log('CLICKED!');
 
     // Replaces all newline characters with <br> tags.
     consOut = consOut.replace(/(?:\r\n|\r|\n)/g, '<br>');

--- a/src/app/components/run-button/run-button.component.ts
+++ b/src/app/components/run-button/run-button.component.ts
@@ -1,3 +1,4 @@
+import { ConsoleTextService } from './../../services/console-text.service';
 import { Component, HostListener } from '@angular/core';
 import { InterpreterService } from 'src/app/services/interpreter.service';
 
@@ -8,10 +9,20 @@ import { InterpreterService } from 'src/app/services/interpreter.service';
 })
 export class RunButtonComponent {
 
-  constructor(private interpreter: InterpreterService) {}
+  constructor(private interpreter: InterpreterService,
+              private consoleTextService: ConsoleTextService) {}
 
   @HostListener('click')
   onClick() {
+    let source = this.consoleTextService.getInput();
+    source = source.replace(/^(&nbsp;|<br>)+/, '');
+    console.log(source);
+    let [consOut, shellOut] = this.interpreter.evaluate(source);
     console.log('CLICKED!');
+
+    // Replaces all newline characters with <br> tags.
+    consOut = consOut.replace(/(?:\r\n|\r|\n)/g, '<br>');
+
+    this.consoleTextService.setOutput(consOut);
   }
 }

--- a/src/app/logic/lexer.ts
+++ b/src/app/logic/lexer.ts
@@ -15,7 +15,7 @@ export class Lexer {
   }
 
   public lex(source: string): Array<Token> | Error {
-
+    this.positionTracker = new PositionTracker(0, 1, 1);
     let tokens: Array<Token> = [];
 
     while (source.length !== 0 && this.positionTracker.getIndex() < source.length) {

--- a/src/app/services/console-text.service.spec.ts
+++ b/src/app/services/console-text.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ConsoleTextService } from './console-text.service';
+
+describe('ConsoleTextService', () => {
+  let service: ConsoleTextService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ConsoleTextService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/console-text.service.ts
+++ b/src/app/services/console-text.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConsoleTextService {
+  private input: string = null;
+  private output: string = null;
+
+  public getInput(): string { return this.input; }
+
+  public setInput(newInput): void { this.input = newInput; }
+
+  public getOutput(): string { return this.output; }
+
+  public setOutput(newOutput: string): void { this.output = newOutput; }
+}

--- a/src/app/services/interpreter.service.ts
+++ b/src/app/services/interpreter.service.ts
@@ -49,7 +49,6 @@ export class InterpreterService {
     else {
       this.parser = new Parser(lexerOutput);
       let parseResult: ParseResult = this.parser.parse();
-      console.log(parseResult);
 
       if (parseResult.getError() !== null) {
         consoleOutput = shellOutput = parseResult.getError().getErrorMessage();


### PR DESCRIPTION
The play button is now able to read the `Code` window source code and run it through the `Pseudo` interpreter to generate the appropriate console output in the `Output` window. Note: at the moment, empty spaces that are added to indent code, seem to through invalid character errors as a result of the representation of the `innerText` in the DOM. This still needs to be fixed, but other than that, the IDE understands the correct syntax.